### PR TITLE
Added field created by Popup Maker to ignored fields

### DIFF
--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -22,3 +22,18 @@ function exclude_ctct_forms( $excluded ) {
 
 // If the WordPress Calls to Action plug-in is installed, exclude our post type to conflict.
 add_filter( 'cta_excluded_post_types', 'exclude_ctct_forms' );
+
+/**
+ * Ignore the field added by Popup Maker from being processed by Constant Contact.
+ *
+ * @since 1.4.0
+ *
+ * @param array $ignored The array of fields that Constant Contact should ignore.
+ * @return array
+ */
+function constant_contact_exclude_pum( $ignored ) {
+	$ignored[] = 'pum_form_popup_id';
+
+	return $ignored;
+}
+add_filter( 'constant_contact_ignored_post_form_values', 'constant_contact_exclude_pum' );


### PR DESCRIPTION
**Closes**
https://github.com/WebDevStudios/constant-contact-forms/issues/272

**Description**
A hidden input added by the plugin, Popup Maker (https://wordpress.org/plugins/popup-maker/), was causing an error. This field has been added to the list of fields that Constant Contact should not process.