### PR TITLE
Update Gutenberg form select

### DIFF
--- a/assets/js/ctct-plugin-gutenberg/components/single-form-select.js
+++ b/assets/js/ctct-plugin-gutenberg/components/single-form-select.js
@@ -26,7 +26,7 @@ class SingleFormSelect extends Component {
 	async componentDidMount() {
 
 		try {
-			const results = await apiFetch( { path: '/wp-json/wp/v2/ctct_forms' } );
+			const results = await apiFetch( { path: '/?rest_route=/wp/v2/ctct_forms' } );
 			const forms = results.map( result => ( { label: result.title.rendered, value: result.id } ) );
 			this.setState( { forms: [...this.state.forms, ...forms ] } );
 		} catch ( e ) {


### PR DESCRIPTION
- Use ?rest_route= instead of /wp-json for permalink compatability.

Closes #343 

Instead of checking the permalink setting, I just used `?rest_route` explicitly. This seems to work despite different Permalink structures, so I'm confident this will be ok. Tested with Plain Permalinks as well as some of the other options, forms loaded as expected.