### PR TITLE
Add Installation How-To Link to FAQs

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -179,6 +179,9 @@ BONUS: If you have a Constant Contact account, all new email addresses that you 
 
 == Frequently Asked Questions ==
 
+#### Installation and Setup
+https://knowledgebase.constantcontact.com/articles/KnowledgeBase/10054-WordPress-Integration-with-Constant-Contact
+
 #### Constant Contact Forms Options
 http://knowledgebase.constantcontact.com/articles/KnowledgeBase/18260-WordPress-Constant-Contact-Forms-Options
 


### PR DESCRIPTION
Closes #355 

Submitting this against `master` and not adding a version milestone just yet, because we're going to push directly to WordPress without a version number update etc. — [reference](https://github.com/WebDevStudios/constant-contact-forms/issues/355#issuecomment-483371330)