### PR TITLE
Spotfix: Disable Certain Sasslint Rules Across SCSS Files

### DIFF
--- a/assets/sass/_admin-forms.scss
+++ b/assets/sass/_admin-forms.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format no-qualifying-elements id-name-format
 .post-type-ctct_forms {
 	.misc-pub-section {
 		&.misc-pub-visibility,

--- a/assets/sass/_admin-global-no-connection.scss
+++ b/assets/sass/_admin-global-no-connection.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format no-qualifying-elements id-name-format
 #adminmenu .wp-submenu a[href="edit.php?post_type=ctct_forms&page=ctct_options_connect"] {
   color: rgb(58, 209, 130);
 }

--- a/assets/sass/_admin-gutenberg.scss
+++ b/assets/sass/_admin-gutenberg.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format no-qualifying-elements id-name-format
 //--------------------------------------------------------------
 // Gutenberg Admin
 //--------------------------------------------------------------

--- a/assets/sass/_admin-notices.scss
+++ b/assets/sass/_admin-notices.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format no-qualifying-elements id-name-format
 .updated.ctct-admin-notice,
 .error.ctct-admin-notice {
 	padding: 1em 38px 1em 1em ;

--- a/assets/sass/_admin-pages.scss
+++ b/assets/sass/_admin-pages.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format no-qualifying-elements id-name-format
 //--------------------------------------------------------------
 // About Page
 //--------------------------------------------------------------

--- a/assets/sass/_compatibility.scss
+++ b/assets/sass/_compatibility.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format no-qualifying-elements id-name-format
 .ctct-twentyfourteen {
   .ctct-form-field input {
 	width: 100%;

--- a/assets/sass/_forms.scss
+++ b/assets/sass/_forms.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format no-qualifying-elements id-name-format
 //--------------------------------------------------------------
 //   FORMS
 //--------------------------------------------------------------

--- a/assets/sass/_global.scss
+++ b/assets/sass/_global.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format no-qualifying-elements id-name-format
 //--------------------------------------------------------------
 //   Global styling goes here
 //--------------------------------------------------------------

--- a/assets/sass/_inputs.scss
+++ b/assets/sass/_inputs.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format no-qualifying-elements id-name-format
 //--------------------------------------------------------------
 //   INPUTS
 //--------------------------------------------------------------

--- a/assets/sass/_layout.scss
+++ b/assets/sass/_layout.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format no-qualifying-elements id-name-format
 //--------------------------------------------------------------
 //   Layout helpers
 //--------------------------------------------------------------

--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format no-qualifying-elements id-name-format
 //--------------------------------------------------------------
 //   MIXINS
 //--------------------------------------------------------------

--- a/assets/sass/_modal.scss
+++ b/assets/sass/_modal.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format no-qualifying-elements id-name-format
 @import 'variables';
 @import 'mixins';
 

--- a/assets/sass/_oath.scss
+++ b/assets/sass/_oath.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format no-qualifying-elements id-name-format
 //--------------------------------------------------------------
 // Disconnect Page
 //--------------------------------------------------------------

--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format no-qualifying-elements id-name-format
 //--------------------------------------------------------------
 //   COLORS
 //--------------------------------------------------------------

--- a/assets/sass/admin-style.scss
+++ b/assets/sass/admin-style.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format no-qualifying-elements id-name-format
 //--------------------------------------------------------------
 //   Let's import all the things - admin-style.css
 //--------------------------------------------------------------

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable class-name-format no-qualifying-elements id-name-format
 //--------------------------------------------------------------
 //   Let's import all the things - style.css
 //--------------------------------------------------------------


### PR DESCRIPTION
- Kind-of an off-shoot of #212 
- Disables certain rules that are not really applicable for this project
- This reduces noise in from the Sasslinter generally, making the flags more useful and easy to parse!