### PR TITLE
Add Composer Dist Command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "constantcontact/constant-contact-forms",
-  "description": "Official WordPress plugin for Constant Contact Forms",
-  "license": "GPLv3",
+  "description": "Official WordPress plugin for Constant Contact Forms.",
+  "license": "GPL-3.0-or-later",
   "homepage": "https://www.constantcontact.com",
   "require": {
     "monolog/monolog": "1.24",
@@ -22,5 +22,14 @@
       "name": "WebDevStudios",
       "homepage": "https://www.webdevstudios.com"
     }
-  ]
+  ],
+  "scripts": {
+		"dist": [
+			"rm -rf ./vendor",
+			"npm run build",
+			"@composer install --no-dev -a",
+			"@composer archive --format=zip --file constant-contact-forms",
+			"mv constant-contact-forms.zip $HOME/Desktop"
+		]
+	}
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "git@github.com/WebDevStudios/constant-contact-forms.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "GPL-3.0-or-later",
   "bugs": {
     "url": "https://github.com/WebDevStudios/constant-contact-forms/issues"
   },


### PR DESCRIPTION
### [CC-100](https://webdevstudios.atlassian.net/jira/software/projects/CC/boards/9?selectedIssue=CC-100)

Adds `composer dist` build script for easier packaging of the plugin into a .zip for WordPress.org distribution.