### PR TITLE
CC-29: Add Field ID to input_classes Filter

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -54,8 +54,6 @@ class ConstantContact_API {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @todo Replace SDK: Initialize a lighter, custom client here instead of the SDK.
-	 *
 	 * @return object ConstantContact_API.
 	 */
 	public function cc() {

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -54,6 +54,8 @@ class ConstantContact_API {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @todo Replace SDK: Initialize a lighter, custom client here instead of the SDK.
+	 *
 	 * @return object ConstantContact_API.
 	 */
 	public function cc() {

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -1003,9 +1003,10 @@ class ConstantContact_Display {
 		 * @since  1.2.0
 		 * @param  array  $classes Array of classes to apply to the field.
 		 * @param  string $type    The field type being rendered.
+		 * @param  string $f_id    Field ID.
 		 * @return array
 		 */
-		$classes = apply_filters( 'constant_contact_input_classes', $classes, $type );
+		$classes = apply_filters( 'constant_contact_input_classes', $classes, $type, $f_id );
 
 		/**
 		 * Filters whether or not to remove characters from potential maxlength attribute value.
@@ -1095,9 +1096,10 @@ class ConstantContact_Display {
 		 *
 		 * @param array  $classes Array of classes to apply to the field.
 		 * @param string $type    The field type being rendered.
+		 * @param string $f_id    Field ID.
 		 * @return array
 		 */
-		$classes = apply_filters( 'constant_contact_input_classes', $classes, $type );
+		$classes = apply_filters( 'constant_contact_input_classes', $classes, $type, $f_id );
 
 		$markup  = $this->field_top( $type, $name, $f_id, $label, false, false );
 		$markup .= '<input type="' . $type . '" name="' . $f_id . '" id="' . $f_id . '" value="' . $value . '" class="' . implode( ' ', $classes ) . '" />';

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -1071,11 +1071,11 @@ class ConstantContact_Display {
 	 * @return string HTML markup for checkbox.
 	 */
 	public function checkbox( $name = '', $f_id = '', $value = '', $label = '' ) {
-		$name    = sanitize_text_field( $name );
-		$f_id    = sanitize_title( $f_id );
-		$value   = sanitize_text_field( $value );
-		$label   = esc_attr( $label );
-		$type    = 'checkbox';
+		$name  = sanitize_text_field( $name );
+		$f_id  = sanitize_title( $f_id );
+		$value = sanitize_text_field( $value );
+		$label = esc_attr( $label );
+		$type  = 'checkbox';
 
 		$classes = [ 'ctct-' . esc_attr( $type ) ];
 
@@ -1085,8 +1085,6 @@ class ConstantContact_Display {
 		 * @since  1.2.0
 		 * @param  array  $classes Array of classes to apply to the field.
 		 * @param  string $type    The field type being rendered.
-		 * @param  int    $form_id Form ID.
-		 * @param  int    $f_id    Field ID.
 		 * @return array
 		 */
 		$classes = apply_filters( 'constant_contact_input_classes', $classes, $type ); // @todo if/when we start using the checkbox field type, pass in a $form_id and $f_id value.

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -259,6 +259,7 @@ class ConstantContact_Display {
 
 		$this->set_global_form_css();
 		$this->set_specific_form_css( $form_id );
+
 		$return           = '';
 		$form_err_display = '';
 		$error_message    = false;
@@ -394,7 +395,6 @@ class ConstantContact_Display {
 	 * @return string URL of current page.
 	 */
 	public function get_current_page() {
-
 		global $wp;
 
 		$request = ( isset( $wp->request ) && $wp->request ) ? $wp->request : null;
@@ -424,7 +424,6 @@ class ConstantContact_Display {
 	 * @return mixed.
 	 */
 	public function add_verify_fields( $form_data ) {
-
 		if (
 			isset( $form_data ) &&
 			isset( $form_data['options'] ) &&
@@ -464,7 +463,6 @@ class ConstantContact_Display {
 	 * @return string
 	 */
 	public function build_form_fields( $form_data, $old_values, $req_errors ) {
-
 		$return  = '';
 		$form_id = absint( $form_data['options']['form_id'] );
 
@@ -712,7 +710,6 @@ class ConstantContact_Display {
 	 * @return mixed Submitted value.
 	 */
 	public function get_submitted_value( $value = '', $map = '', $field = [], $submitted_vals = [] ) {
-
 		if ( $value ) {
 			return $value;
 		}
@@ -1115,7 +1112,7 @@ class ConstantContact_Display {
 		$form_id    = 0 === $form_id ? get_the_ID() : $form_id;
 		$maybe_form = get_post( $form_id );
 
-		if ( ! isset( $maybe_form->post_type ) || 'ctct_forms' !== $maybe_form->post_type ) {
+		if ( 'ctct_forms' !== $maybe_form->post_type ) {
 			return 0;
 		}
 
@@ -1225,7 +1222,6 @@ class ConstantContact_Display {
 	 * @return string HTML markup
 	 */
 	public function get_optin_markup( $label, $value, $show ) {
-
 		$checked = $show ? '' : 'checked';
 
 		$markup  = $this->field_top( 'checkbox', 'ctct-opt-in', 'ctct-opt-in', $label, false, false );
@@ -1250,7 +1246,6 @@ class ConstantContact_Display {
 	 * @return string field HTML markup.
 	 */
 	public function address( $name = '', $f_id = '', $value = [], $desc = '', $req = false, $field_error = '', $label_placement = 'top' ) {
-
 		$street = esc_html__( 'Street Address', 'constant-contact-forms' );
 		$line_2 = esc_html__( 'Address Line 2', 'constant-contact-forms' );
 		$city   = esc_html__( 'City', 'constant-contact-forms' );
@@ -1439,7 +1434,6 @@ class ConstantContact_Display {
 	 * @return string Fields HTML markup.
 	 */
 	public function dates( $name = '', $f_id = '', $value = [], $desc = '', $req = false, $field_error = '' ) {
-
 		$month = esc_html__( 'Month', 'constant-contact-forms' );
 		$day   = esc_html__( 'Day', 'constant-contact-forms' );
 		$year  = esc_html__( 'Year', 'constant-contact-forms' );
@@ -1480,7 +1474,6 @@ class ConstantContact_Display {
 	 * @return string field markup.
 	 */
 	public function get_date_dropdown( $text = '', $f_id = '', $type = '', $selected_value = '', $req = false ) {
-
 		$f_id = str_replace( 'birthday', 'birthday_' . $type, $f_id );
 		$f_id = str_replace( 'anniversary', 'anniversary_' . $type, $f_id );
 
@@ -1508,7 +1501,6 @@ class ConstantContact_Display {
 	 * @return string HTML markup.
 	 */
 	public function get_date_options( $text = '', $values = [], $prev_selected_values = [] ) {
-
 		$return = '<option value="">' . sanitize_text_field( $text ) . '</option>';
 
 		if ( ! is_array( $values ) ) {

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -950,7 +950,6 @@ class ConstantContact_Display {
 	public function input( $type = 'text', $name = '', $id = '', $value = '', $label = '', $req = false, $f_only = false, $field_error = false, $form_id = 0, $label_placement = '' ) {
 		$name                  = sanitize_text_field( $name );
 		$f_id                  = sanitize_title( $id );
-		$form_id               = $this->get_true_form_id( $form_id );
 		$input_inline_styles   = '';
 		$label_placement_class = 'ctct-label-' . $label_placement;
 		$specific_form_styles  = $this->specific_form_styles;
@@ -1074,7 +1073,6 @@ class ConstantContact_Display {
 	public function checkbox( $name = '', $f_id = '', $value = '', $label = '' ) {
 		$name    = sanitize_text_field( $name );
 		$f_id    = sanitize_title( $f_id );
-		$form_id = $this->get_true_form_id();
 		$value   = sanitize_text_field( $value );
 		$label   = esc_attr( $label );
 		$type    = 'checkbox';
@@ -1091,32 +1089,13 @@ class ConstantContact_Display {
 		 * @param  int    $f_id    Field ID.
 		 * @return array
 		 */
-		$classes = apply_filters( 'constant_contact_input_classes', $classes, $type, $form_id, $f_id );
+		$classes = apply_filters( 'constant_contact_input_classes', $classes, $type ); // @todo if/when we start using the checkbox field type, pass in a $form_id and $f_id value.
 
 		$markup  = $this->field_top( $type, $name, $f_id, $label, false, false );
 		$markup .= '<input type="' . $type . '" name="' . $f_id . '" id="' . $f_id . '" value="' . $value . '" class="' . implode( ' ', $classes ) . '" />';
 		$markup .= $this->field_bottom( $name, ' ' . $label );
 
 		return $markup;
-	}
-
-	/**
-	 * Gets post ID of the CTCT form, instead of the ID of the post it's embedded in.
-	 *
-	 * @since TBD
-	 *
-	 * @param int $form_id Optional. Form ID, defaults to 0.
-	 * @return int 0 if could not find a post ID for a CTCT form.
-	 */
-	private function get_true_form_id( $form_id = 0 ) {
-		$form_id    = 0 === $form_id ? get_the_ID() : $form_id;
-		$maybe_form = get_post( $form_id );
-
-		if ( 'ctct_forms' !== $maybe_form->post_type ) {
-			return 0;
-		}
-
-		return $form_id;
 	}
 
 	/**

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -998,11 +998,11 @@ class ConstantContact_Display {
 		 * @since  1.2.0
 		 * @param  array  $classes Array of classes to apply to the field.
 		 * @param  string $type    The field type being rendered.
-		 * @param  int    $f_id    Field ID.
 		 * @param  int    $form_id Form ID.
+		 * @param  int    $f_id    Field ID.
 		 * @return array
 		 */
-		$classes = apply_filters( 'constant_contact_input_classes', $classes, $type, $f_id, $form_id );
+		$classes = apply_filters( 'constant_contact_input_classes', $classes, $type, $form_id, $f_id );
 
 		/**
 		 * Filters whether or not to remove characters from potential maxlength attribute value.
@@ -1090,11 +1090,11 @@ class ConstantContact_Display {
 		 * @since  1.2.0
 		 * @param  array  $classes Array of classes to apply to the field.
 		 * @param  string $type    The field type being rendered.
-		 * @param  int    $f_id    Field ID.
 		 * @param  int    $form_id Form ID.
+		 * @param  int    $f_id    Field ID.
 		 * @return array
 		 */
-		$classes = apply_filters( 'constant_contact_input_classes', $classes, $type, $f_id, $form_id );
+		$classes = apply_filters( 'constant_contact_input_classes', $classes, $type, $form_id, $f_id );
 
 		$markup  = $this->field_top( $type, $name, $f_id, $label, false, false );
 		$markup .= '<input type="' . $type . '" name="' . $f_id . '" id="' . $f_id . '" value="' . $value . '" class="' . implode( ' ', $classes ) . '" />';

--- a/readme.txt
+++ b/readme.txt
@@ -36,7 +36,8 @@ BONUS: If you have a Constant Contact account, all new email addresses that you 
 == Changelog ==
 
 = TBD =
-* Tweak: Added the field ID as third parameter to the `constant_contact_input_classes` filter.
+* Tweak: Added the form ID as third parameter to the `constant_contact_input_classes` filter.
+* Tweak: Added the input field ID as fourth parameter to the `constant_contact_input_classes` filter.
 
 = 1.7.0 =
 * New - Added support for Google reCAPTCHA version 3

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,9 @@ BONUS: If you have a Constant Contact account, all new email addresses that you 
 
 == Changelog ==
 
+= TBD =
+* Tweak: Added the field ID as third parameter to the `constant_contact_input_classes` filter.
+
 = 1.7.0 =
 * New - Added support for Google reCAPTCHA version 3
 * Fix - Fixed with debug log deletion and dialog closing


### PR DESCRIPTION
[CC-29](https://webdevstudios.atlassian.net/browse/CC-29)
---

Adds the form ID and field ID as third and fourth parameters to the `constant_contact_input_classes` filter.