### PR TITLE
CC-12: Separate out options page into tabs

### DIFF
--- a/assets/css/admin-style.css
+++ b/assets/css/admin-style.css
@@ -1236,7 +1236,7 @@ a.ctct-notice-dismiss {
   width: 500px;
 }
 
-.cmb2-options-page #ctct_option_metabox_settings .cmb2-metabox > .cmb-row {
+.cmb2-options-page[class*='option-ctct_options_settings_'] .cmb2-metabox > .cmb-row {
   background: transparent;
   border: none;
   box-shadow: none;

--- a/assets/sass/_admin-pages.scss
+++ b/assets/sass/_admin-pages.scss
@@ -319,7 +319,7 @@
 
 .cmb2-options-page {
 
-	#ctct_option_metabox_settings {
+	&[class*='option-ctct_options_settings_'] {
 
 		.cmb2-metabox > .cmb-row {
 			background: transparent;

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -60,7 +60,7 @@ class ConstantContact_Settings {
 		$this->plugin = $plugin;
 		$this->register_hooks();
 
-		// Init cmb title property.
+		// Init CMB2 metabox titles, used as tab titles on settings page.
 		$this->metabox_titles = [
 			'general' => esc_html__( 'General', 'constant-contact-forms' ),
 			'spam'    => esc_html__( 'Spam Control', 'constant-contact-forms' ),

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -21,7 +21,7 @@ class ConstantContact_Settings {
 	 * Option key, and option page slug.
 	 *
 	 * @since 1.0.0
-	 * @var string
+	 * @var   string
 	 */
 	private $key = 'ctct_options_settings';
 
@@ -29,7 +29,7 @@ class ConstantContact_Settings {
 	 * Settings page metabox id.
 	 *
 	 * @since 1.0.0
-	 * @var string
+	 * @var   string
 	 */
 	private $metabox_id = 'ctct_option_metabox_settings';
 
@@ -37,7 +37,7 @@ class ConstantContact_Settings {
 	 * Settings page metabox titles by id.
 	 *
 	 * @since NEXT
-	 * @var array
+	 * @var   array|null
 	 */
 	private $metabox_titles = [
 		'general' => 'General',
@@ -45,18 +45,12 @@ class ConstantContact_Settings {
 		'support' => 'Support',
 	];
 
-	/**
-	 * Settings options page.
-	 *
-	 * @var string
-	 */
-	private $options_page;
 
 	/**
 	 * Parent plugin class.
 	 *
 	 * @since 1.0.0
-	 * @var object
+	 * @var   object
 	 */
 	protected $plugin;
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -42,7 +42,6 @@ class ConstantContact_Settings {
 	private $metabox_titles = [
 		'general' => 'General',
 		'spam'    => 'Spam Control',
-		'form'    => 'Form',
 		'support' => 'Support',
 	];
 
@@ -421,6 +420,41 @@ class ConstantContact_Settings {
 				}
 			}
 		}
+
+		$before_global_css = sprintf(
+			'<hr /><h2>%s</h2>',
+			esc_html__( 'Global Form CSS Settings', 'constant-contact-forms' )
+		);
+
+		$cmb->add_field( [
+			'name'        => esc_html__( 'CSS Classes', 'constant-contact_forms' ),
+			'id'          => '_ctct_form_custom_classes',
+			'type'        => 'text',
+			'description' => esc_html__(
+					'Provide custom classes for the form separated by a single space.',
+					'constant-contact-forms'
+			),
+			'before_row'  => $before_global_css,
+		] );
+
+		$cmb->add_field( [
+			'name'             => esc_html__( 'Label Placement', 'constant-contact-forms' ),
+			'id'               => '_ctct_form_label_placement',
+			'type'             => 'select',
+			'default'          => 'top',
+			'show_option_none' => false,
+			'options'          => [
+				'top'    => esc_html__( 'Top', 'constant-contact-forms' ),
+				'left'   => esc_html__( 'Left', 'constant-contact-forms' ),
+				'right'  => esc_html__( 'Right', 'constant-contact-forms' ),
+				'bottom' => esc_html__( 'Bottom', 'constant-contact-forms' ),
+				'hidden' => esc_html__( 'Hidden', 'constant-contact-forms' ),
+			],
+			'description'      => esc_html__(
+				'Choose the position for the labels of the form elements.',
+				'constant-contact-forms'
+			),
+		] );
 	}
 
 	/**
@@ -433,7 +467,7 @@ class ConstantContact_Settings {
 		$cmb = new_cmb2_box( $this->get_cmb_args( 'spam' ) );
 
 		$before_recaptcha = sprintf(
-			'<hr/><h2>%s</h2>%s',
+			'<h2>%s</h2>%s',
 			esc_html__( 'Google reCAPTCHA', 'constant-contact-forms' ),
 			'<div class="discover-recaptcha">' . __( 'Learn more and get an <a href="https://www.google.com/recaptcha/intro/" target="_blank">API site key</a>', 'constant-contact-forms' ) . '</div>'
 		);
@@ -493,51 +527,6 @@ class ConstantContact_Settings {
 	}
 
 	/**
-	 * Register 'Form' settings tab fields.
-	 *
-	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
-	 */
-	protected function register_fields_form() {
-		$cmb = new_cmb2_box( $this->get_cmb_args( 'form' ) );
-
-		$before_global_css = sprintf(
-			'<hr /><h2>%s</h2>',
-			esc_html__( 'Global Form CSS Settings', 'constant-contact-forms' )
-		);
-
-		$cmb->add_field( [
-			'name'        => esc_html__( 'CSS Classes', 'constant-contact_forms' ),
-			'id'          => '_ctct_form_custom_classes',
-			'type'        => 'text',
-			'description' => esc_html__(
-					'Provide custom classes for the form separated by a single space.',
-					'constant-contact-forms'
-			),
-			'before_row'  => $before_global_css,
-		] );
-
-		$cmb->add_field( [
-			'name'             => esc_html__( 'Label Placement', 'constant-contact-forms' ),
-			'id'               => '_ctct_form_label_placement',
-			'type'             => 'select',
-			'default'          => 'top',
-			'show_option_none' => false,
-			'options'          => [
-				'top'    => esc_html__( 'Top', 'constant-contact-forms' ),
-				'left'   => esc_html__( 'Left', 'constant-contact-forms' ),
-				'right'  => esc_html__( 'Right', 'constant-contact-forms' ),
-				'bottom' => esc_html__( 'Bottom', 'constant-contact-forms' ),
-				'hidden' => esc_html__( 'Hidden', 'constant-contact-forms' ),
-			],
-			'description'      => esc_html__(
-				'Choose the position for the labels of the form elements.',
-				'constant-contact-forms'
-			),
-		] );
-	}
-
-	/**
 	 * Register 'Support' settings tab fields.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
@@ -547,7 +536,7 @@ class ConstantContact_Settings {
 		$cmb = new_cmb2_box( $this->get_cmb_args( 'support' ) );
 
 		$before_debugging = sprintf(
-			'<hr/><h2>%s</h2>',
+			'<h2>%s</h2>',
 			esc_html__( 'Support', 'constant-contact-forms' )
 		);
 		$cmb->add_field( [

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -58,7 +58,6 @@ class ConstantContact_Settings {
 	 */
 	public function __construct( $plugin ) {
 		$this->plugin = $plugin;
-		$this->register_hooks();
 
 		// Init CMB2 metabox titles, used as tab titles on settings page.
 		$this->metabox_titles = [
@@ -66,6 +65,8 @@ class ConstantContact_Settings {
 			'spam'    => esc_html__( 'Spam Control', 'constant-contact-forms' ),
 			'support' => esc_html__( 'Support', 'constant-contact-forms' ),
 		];
+
+		$this->register_hooks();
 	}
 
 	/**
@@ -79,18 +80,33 @@ class ConstantContact_Settings {
 		add_action( 'admin_menu', [ $this, 'remove_extra_menu_items' ], 999 );
 		add_filter( 'parent_file', [ $this, 'select_primary_menu_item' ] );
 
-		foreach ( array_keys( $this->metabox_titles ) as $cmb_key ) {
-			add_filter( "cmb2_override_option_get_{$this->key}_{$cmb_key}", [ $this, 'get_override' ], 10, 2 );
-			add_filter( "cmb2_override_option_save_{$this->key}_{$cmb_key}", [ $this, 'update_override' ], 10, 2 );
-			add_action( "cmb2_save_options-page_fields_{$this->metabox_id}_{$cmb_key}", [ $this, 'settings_notices' ], 10, 2 );
-		}
-
+		$this->register_metabox_override_hooks();
 		$this->inject_optin_form_hooks();
 
 		add_filter( 'preprocess_comment', [ $this, 'process_optin_comment_form' ] );
 		add_filter( 'authenticate', [ $this, 'process_optin_login_form' ], 10, 3 );
 		add_action( 'cmb2_save_field__ctct_logging', [ $this, 'maybe_init_logs' ], 10, 2 );
 		add_filter( 'ctct_custom_spam_message', [ $this, 'get_spam_error_message' ], 10, 2 );
+	}
+
+	/**
+	 * Add CMB2 hook overrides specific to individual metaboxes.
+	 *
+	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+	 * @since  NEXT
+	 *
+	 * @return void
+	 */
+	protected function register_metabox_override_hooks() {
+		if ( ! is_array( $this->metabox_titles ) ) {
+			return;
+		}
+
+		foreach ( array_keys( $this->metabox_titles ) as $cmb_key ) {
+			add_filter( "cmb2_override_option_get_{$this->key}_{$cmb_key}", [ $this, 'get_override' ], 10, 2 );
+			add_filter( "cmb2_override_option_save_{$this->key}_{$cmb_key}", [ $this, 'update_override' ], 10, 2 );
+			add_action( "cmb2_save_options-page_fields_{$this->metabox_id}_{$cmb_key}", [ $this, 'settings_notices' ], 10, 2 );
+		}
 	}
 
 	/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -360,8 +360,11 @@ class ConstantContact_Settings {
 			if ( $lists && is_array( $lists ) ) {
 
 				$before_optin = sprintf(
-					'<hr/><h2>%s</h2>',
-					esc_html__( 'Advanced Opt-in', 'constant-contact-forms' )
+					/* translators: 1: horizontal rule and opening heading tag, 2: opt-in section heading, 3: closing heading tag */
+					'%1$s%2$s%3$s',
+					'<hr/><h2>',
+					esc_html__( 'Advanced Opt-in', 'constant-contact-forms' ),
+					'</h2>'
 				);
 
 				$cmb->add_field( [
@@ -421,8 +424,11 @@ class ConstantContact_Settings {
 		}
 
 		$before_global_css = sprintf(
-			'<hr /><h2>%s</h2>',
-			esc_html__( 'Global Form CSS Settings', 'constant-contact-forms' )
+			/* translators: 1: horizontal rule and opening heading tag, 2: global css section heading, 3: closing heading tag */
+			'%1$s%2$s%3$s',
+			'<hr><h2>',
+			esc_html__( 'Global Form CSS Settings', 'constant-contact-forms' ),
+			'</h2>'
 		);
 
 		$cmb->add_field( [
@@ -466,9 +472,16 @@ class ConstantContact_Settings {
 		$cmb = new_cmb2_box( $this->get_cmb_args( 'spam' ) );
 
 		$before_recaptcha = sprintf(
-			'<h2>%s</h2>%s',
+			/* translators: 1: opening heading tag, 2: reCaptcha section heading, 3: closing heading tag, 4: opening div tag, 5: text before 'learn more' link, 6: open 'learn more' link tag, 7: 'learn more' link text, 8: closing 'learn more' link and div tags */
+			'%1$s%2$s%3$s%4$s%5$s%6$s%7$s%8$s',
+			'<h2>',
 			esc_html__( 'Google reCAPTCHA', 'constant-contact-forms' ),
-			'<div class="discover-recaptcha">' . __( 'Learn more and get an <a href="https://www.google.com/recaptcha/intro/" target="_blank">API site key</a>', 'constant-contact-forms' ) . '</div>'
+			'</h2>',
+			'<div class="discover-recaptcha">',
+			esc_html__( 'Learn more and get an ', 'constant-contact-forms' ),
+			'<a href="https://www.google.com/recaptcha/intro/" target="_blank">',
+			esc_html__( 'API site key', 'constant-contact-forms' ),
+			'</a></div>'
 		);
 
 		$cmb->add_field( [
@@ -503,15 +516,15 @@ class ConstantContact_Settings {
 			],
 		] );
 
-		$description  = '<div class="description">';
-		$description .= esc_html__( 'This message displays when the plugin detects spam data.', 'constant-contact-forms' );
-		$description .= esc_html__( 'Note that this message may be overriden on a per-post basis.', 'constant-contact-forms' );
-		$description .= '</div>';
-
 		$before_message = sprintf(
-			'<hr/><h2>%s</h2>%s',
-			__( 'Suspected Bot Error Message', 'constant-contact-forms' ),
-			$description
+			/* translators: 1: horizontal rule and opening heading tag, 2: spam section heading, 3: closing heading tag, 4: opening div tag for description, 5: spam section description, 6: closing div tag */
+			'%1$s%2$s%3$s%4$s%5$s%6$s',
+			'<hr/><h2>',
+			esc_html__( 'Suspected Bot Error Message', 'constant-contact-forms' ),
+			'</h2>',
+			'<div class="description">',
+			esc_html__( 'This message displays when the plugin detects spam data. Note that this message may be overriden on a per-post basis.', 'constant-contact-forms' ),
+			'</div>'
 		);
 
 		$cmb->add_field(
@@ -535,8 +548,11 @@ class ConstantContact_Settings {
 		$cmb = new_cmb2_box( $this->get_cmb_args( 'support' ) );
 
 		$before_debugging = sprintf(
-			'<h2>%s</h2>',
-			esc_html__( 'Support', 'constant-contact-forms' )
+			/* translators: 1: opening heading tag, 2: support section heading, 3: closing heading tag */
+			'%1$s%2$s%3$s',
+			'<h2>',
+			esc_html__( 'Support', 'constant-contact-forms' ),
+			'</h2>'
 		);
 		$cmb->add_field( [
 			'name'       => esc_html__( 'Enable logging for debugging purposes.', 'constant-contact-forms' ),

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -79,6 +79,8 @@ class ConstantContact_Settings {
 	public function register_hooks() {
 		add_action( 'cmb2_admin_init', [ $this, 'add_options_page_metaboxes' ] );
 
+		add_action( 'admin_menu', [ $this, 'remove_extra_menu_items' ], 999 );
+
 		add_filter( 'cmb2_override_option_get_' . $this->key, [ $this, 'get_override' ], 10, 2 );
 		add_filter( 'cmb2_override_option_save_' . $this->key, [ $this, 'update_override' ], 10, 2 );
 		add_action( "cmb2_save_options-page_fields_{$this->metabox_id}", [ $this, 'settings_notices' ], 10, 2 );
@@ -158,6 +160,22 @@ class ConstantContact_Settings {
 	public function add_options_page_metaboxes() {
 		$this->register_fields_general();
 		$this->register_fields_recaptcha();
+	}
+
+	/**
+	 * Remove secondary settings page menu items.
+	 *
+	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+	 * @since  NEXT
+	 */
+	public function remove_extra_menu_items() {
+		foreach ( array_keys( $this->metabox_titles ) as $cmb_key ) {
+			if ( 'general' === $cmb_key ) {
+				continue;
+			}
+
+			remove_submenu_page( 'edit.php?post_type=ctct_forms', "{$this->key}_{$cmb_key}" );
+		}
 	}
 
 	/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -196,7 +196,7 @@ class ConstantContact_Settings {
 	 * @param  string $file The parent file.
 	 * @return string       The parent file.
 	 */
-	public function select_primary_menu_item( $file ) : string {
+	public function select_primary_menu_item( $file ) {
 		global $plugin_page;
 
 		$plugin_page = false !== strpos( $plugin_page, $this->key ) ? "{$this->key}_general" : $plugin_page; // phpcs:ignore -- Okay overriding of WP global
@@ -244,7 +244,7 @@ class ConstantContact_Settings {
 	 * @param  CMB2_Options_Hookup $cmb_options The CMB2_Options_Hookup object.
 	 * @return array                            Array of option tabs.
 	 */
-	protected function get_option_tabs( CMB2_Options_Hookup $cmb_options ) : array {
+	protected function get_option_tabs( CMB2_Options_Hookup $cmb_options ) {
 		$tab_group = $cmb_options->cmb->prop( 'tab_group' );
 		$tabs      = [];
 
@@ -259,7 +259,8 @@ class ConstantContact_Settings {
 				continue;
 			}
 
-			$tabs[ "{$this->key}_{$cmb_key}" ] = $cmb->prop( 'tab_title' ) ?? $cmb->prop( 'title' );
+			$tab_title                         = $cmb->prop( 'tab_title' );
+			$tabs[ "{$this->key}_{$cmb_key}" ] = empty( $tab_title ) ? $cmb->prop( 'title' ) : $tab_title;
 		}
 
 		return $tabs;
@@ -273,8 +274,10 @@ class ConstantContact_Settings {
 	 *
 	 * @return string Current tab.
 	 */
-	protected function get_current_tab() : string {
-		return filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) ?? "{$this->key}_general";
+	protected function get_current_tab() {
+		$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
+
+		return empty( $page ) ? "{$this->key}_general" : $page;
 	}
 
 	/**
@@ -286,7 +289,7 @@ class ConstantContact_Settings {
 	 * @param  string $option_key CMB tab key.
 	 * @return string             URL to CMB tab.
 	 */
-	protected function get_tab_link( $option_key ) : string {
+	protected function get_tab_link( $option_key ) {
 		$menu_page_url = wp_specialchars_decode( menu_page_url( $option_key, false ) );
 
 		return $menu_page_url;
@@ -301,7 +304,7 @@ class ConstantContact_Settings {
 	 * @param  string $cmb_id Current CMB ID.
 	 * @return array          CMB args.
 	 */
-	protected function get_cmb_args( string $cmb_id ) : array {
+	protected function get_cmb_args( string $cmb_id ) {
 		return [
 			'id'           => "{$this->metabox_id}_{$cmb_id}",
 			'title'        => esc_html__( 'Constant Contact Forms Settings', 'constant-contact-forms' ),

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -39,12 +39,7 @@ class ConstantContact_Settings {
 	 * @since NEXT
 	 * @var   array|null
 	 */
-	private $metabox_titles = [
-		'general' => 'General',
-		'spam'    => 'Spam Control',
-		'support' => 'Support',
-	];
-
+	private $metabox_titles;
 
 	/**
 	 * Parent plugin class.
@@ -64,6 +59,13 @@ class ConstantContact_Settings {
 	public function __construct( $plugin ) {
 		$this->plugin = $plugin;
 		$this->register_hooks();
+
+		// Init cmb title property.
+		$this->metabox_titles = [
+			'general' => 'General',
+			'spam'    => 'Spam Control',
+			'support' => 'Support',
+		];
 	}
 
 	/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -81,9 +81,11 @@ class ConstantContact_Settings {
 
 		add_action( 'admin_menu', [ $this, 'remove_extra_menu_items' ], 999 );
 
-		add_filter( 'cmb2_override_option_get_' . $this->key, [ $this, 'get_override' ], 10, 2 );
-		add_filter( 'cmb2_override_option_save_' . $this->key, [ $this, 'update_override' ], 10, 2 );
-		add_action( "cmb2_save_options-page_fields_{$this->metabox_id}", [ $this, 'settings_notices' ], 10, 2 );
+		foreach ( array_keys( $this->metabox_titles ) as $cmb_key ) {
+			add_filter( "cmb2_override_option_get_{$this->key}_{$cmb_key}", [ $this, 'get_override' ], 10, 2 );
+			add_filter( "cmb2_override_option_save_{$this->key}_{$cmb_key}", [ $this, 'update_override' ], 10, 2 );
+			add_action( "cmb2_save_options-page_fields_{$this->metabox_id}_{$cmb_key}", [ $this, 'settings_notices' ], 10, 2 );
+		}
 
 		$this->inject_optin_form_hooks();
 
@@ -754,7 +756,6 @@ class ConstantContact_Settings {
 	 * @return void
 	 */
 	public function settings_notices( $object_id, $updated ) {
-
 		if ( $object_id !== $this->key || empty( $updated ) ) {
 			return;
 		}
@@ -781,11 +782,11 @@ class ConstantContact_Settings {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $test         Key.
+	 * @param string $ignore       Key.
 	 * @param mixed  $option_value Value to update to.
 	 * @return mixed Site option
 	 */
-	public function update_override( $test, $option_value ) {
+	public function update_override( $ignore, $option_value ) {
 		return update_site_option( $this->key, $option_value );
 	}
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -80,6 +80,7 @@ class ConstantContact_Settings {
 		add_action( 'cmb2_admin_init', [ $this, 'add_options_page_metaboxes' ] );
 
 		add_action( 'admin_menu', [ $this, 'remove_extra_menu_items' ], 999 );
+		add_filter( 'parent_file', [ $this, 'select_primary_menu_item' ] );
 
 		foreach ( array_keys( $this->metabox_titles ) as $cmb_key ) {
 			add_filter( "cmb2_override_option_get_{$this->key}_{$cmb_key}", [ $this, 'get_override' ], 10, 2 );
@@ -178,6 +179,25 @@ class ConstantContact_Settings {
 
 			remove_submenu_page( 'edit.php?post_type=ctct_forms', "{$this->key}_{$cmb_key}" );
 		}
+	}
+
+	/**
+	 * Ensure primary settings page menu item is highlighted.
+	 *
+	 * Override $plugin_page global to ensure "general" menu item active for other settings pages.
+	 *
+	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+	 * @since  NEXT
+	 *
+	 * @param  string $file The parent file.
+	 * @return string       The parent file.
+	 */
+	public function select_primary_menu_item( $file ) : string {
+		global $plugin_page;
+
+		$plugin_page = false !== strpos( $plugin_page, $this->key ) ? "{$this->key}_general" : $plugin_page; // phpcs:ignore -- Okay overriding of WP global
+
+		return $file;
 	}
 
 	/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -40,11 +40,10 @@ class ConstantContact_Settings {
 	 * @var array
 	 */
 	private $metabox_titles = [
-		'general'   => 'General',
-		'recaptcha' => 'reCaptcha',
-		'form'      => 'Form',
-		'support'   => 'Support',
-		'spam'      => 'Spam',
+		'general' => 'General',
+		'spam'    => 'Spam Control',
+		'form'    => 'Form',
+		'support' => 'Support',
 	];
 
 	/**
@@ -425,13 +424,13 @@ class ConstantContact_Settings {
 	}
 
 	/**
-	 * Register 'Google reCAPTCHA' settings tab fields.
+	 * Register 'Spam Control' (incl. Google reCAPTCHA) settings tab fields.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
 	 * @since  NEXT
 	 */
-	protected function register_fields_recaptcha() {
-		$cmb = new_cmb2_box( $this->get_cmb_args( 'recaptcha' ) );
+	protected function register_fields_spam() {
+		$cmb = new_cmb2_box( $this->get_cmb_args( 'spam' ) );
 
 		$before_recaptcha = sprintf(
 			'<hr/><h2>%s</h2>%s',
@@ -470,10 +469,31 @@ class ConstantContact_Settings {
 				'maxlength' => 50,
 			],
 		] );
+
+		$description  = '<div class="description">';
+		$description .= esc_html__( 'This message displays when the plugin detects spam data.', 'constant-contact-forms' );
+		$description .= esc_html__( 'Note that this message may be overriden on a per-post basis.', 'constant-contact-forms' );
+		$description .= '</div>';
+
+		$before_message = sprintf(
+			'<hr/><h2>%s</h2>%s',
+			__( 'Suspected Bot Error Message', 'constant-contact-forms' ),
+			$description
+		);
+
+		$cmb->add_field(
+			[
+				'name'       => esc_html__( 'Error Message', 'constant-contact-forms' ),
+				'id'         => '_ctct_spam_error',
+				'type'       => 'text',
+				'before_row' => $before_message,
+				'default'    => $this->get_default_spam_error(),
+			]
+		);
 	}
 
 	/**
-	 * Register 'form' settings tab fields.
+	 * Register 'Form' settings tab fields.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
 	 * @since  NEXT
@@ -518,7 +538,7 @@ class ConstantContact_Settings {
 	}
 
 	/**
-	 * Register 'support' settings tab fields.
+	 * Register 'Support' settings tab fields.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
 	 * @since  NEXT
@@ -537,37 +557,6 @@ class ConstantContact_Settings {
 			'type'       => 'checkbox',
 			'before_row' => $before_debugging,
 		] );
-	}
-
-	/**
-	 * Register 'spam' settings tab fields.
-	 *
-	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
-	 */
-	protected function register_fields_spam() {
-		$cmb = new_cmb2_box( $this->get_cmb_args( 'spam' ) );
-
-		$description  = '<div class="description">';
-		$description .= esc_html__( 'This message displays when the plugin detects spam data.', 'constant-contact-forms' );
-		$description .= esc_html__( 'Note that this message may be overriden on a per-post basis.', 'constant-contact-forms' );
-		$description .= '</div>';
-
-		$before_message = sprintf(
-			'<hr/><h2>%s</h2>%s',
-			__( 'Suspected Bot Error Message', 'constant-contact-forms' ),
-			$description
-		);
-
-		$cmb->add_field(
-			[
-				'name'       => esc_html__( 'Error Message', 'constant-contact-forms' ),
-				'id'         => '_ctct_spam_error',
-				'type'       => 'text',
-				'before_row' => $before_message,
-				'default'    => $this->get_default_spam_error(),
-			]
-		);
 	}
 
 	/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -150,9 +150,7 @@ class ConstantContact_Settings {
 
 		global $pagenow;
 
-		// phpcs:disable WordPress.Security.NonceVerification -- OK direct-accessing of $_GET.
-		return ( 'edit.php' === $pagenow && isset( $_GET['page'] ) && $this->key === $_GET['page'] );
-		// phpcs:enable WordPress.Security.NonceVerification
+		return ( 'edit.php' === $pagenow && isset( $_GET['page'] ) && $this->key === $_GET['page'] ); // phpcs:ignore -- Okay accessing of $_GET.
 	}
 
 	/**
@@ -619,7 +617,7 @@ class ConstantContact_Settings {
 				<input type="checkbox" value="<?php echo esc_attr( $list ); ?>" class="checkbox" id="ctct_optin" name="ctct_optin_list" />
 				<?php echo esc_attr( $label ); ?>
 			</label>
-			<?php echo constant_contact()->display->get_disclose_text(); ?>
+			<?php echo wp_kses_post( constant_contact()->display->get_disclose_text() ); ?>
 			<?php wp_nonce_field( 'ct_ct_add_to_optin', 'ct_ct_optin' ); ?>
 		</p>
 		<?php
@@ -630,8 +628,6 @@ class ConstantContact_Settings {
 	 * Sends contact to CTCT if optin checked.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @throws Exception
 	 *
 	 * @param array $comment_data Comment form data.
 	 * @return array Comment form data.
@@ -669,11 +665,11 @@ class ConstantContact_Settings {
 			$name    = isset( $comment_data['comment_author'] ) ? $comment_data['comment_author'] : '';
 			$website = isset( $comment_data['comment_author_url'] ) ? $comment_data['comment_author_url'] : '';
 
-			if ( ! isset( $_POST['ctct_optin_list'] ) ) {
+			if ( ! isset( $_POST['ctct_optin_list'] ) ) { // phpcs:ignore -- Okay accessing of $_POST.
 				return $comment_data;
 			}
 
-			$list = sanitize_text_field( wp_unslash( $_POST['ctct_optin_list'] ) );
+			$list = sanitize_text_field( wp_unslash( $_POST['ctct_optin_list'] ) ); // phpcs:ignore -- Okay accessing of $_POST.
 
 			$args = [
 				'list'       => $list,
@@ -693,8 +689,6 @@ class ConstantContact_Settings {
 	 * Sends contact to CTCT if optin checked.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @throws Exception
 	 *
 	 * @param array  $user User.
 	 * @param string $username Login name.
@@ -746,11 +740,11 @@ class ConstantContact_Settings {
 			$name = sanitize_text_field( $user_data->data->display_name );
 		}
 
-		if ( ! isset( $_POST['ctct_optin_list'] ) ) {
+		if ( ! isset( $_POST['ctct_optin_list'] ) ) { // phpcs:ignore -- Okay accessing of $_POST.
 			return $user;
 		}
 
-		$list = sanitize_text_field( wp_unslash( $_POST['ctct_optin_list'] ) );
+		$list = sanitize_text_field( wp_unslash( $_POST['ctct_optin_list'] ) ); // phpcs:ignore -- Okay accessing of $_POST.
 
 		if ( $email ) {
 			$args = [
@@ -860,12 +854,10 @@ class ConstantContact_Settings {
 				<div class="ctct-modal-content">
 					<div class="ctct-modal-header">
 						<a href="#" class="ctct-modal-close" aria-hidden="true">&times;</a>
-						<h2 class="ctct-logo"><img src="<?php echo constant_contact()->url . '/assets/images/constant-contact-logo.png' ?>" alt="<?php echo esc_attr_x( 'Constant Contact logo', 'img alt text', 'constant-contact-forms' ); ?>" /></h2>
+						<h2 class="ctct-logo"><img src="<?php echo esc_url( constant_contact()->url . '/assets/images/constant-contact-logo.png' ); ?>" alt="<?php echo esc_attr_x( 'Constant Contact logo', 'img alt text', 'constant-contact-forms' ); ?>" /></h2>
 					</div>
 					<div class="ctct-modal-body ctct-privacy-modal-body">
-						<?php
-						echo constant_contact_privacy_policy_content();
-						?>
+						<?php echo constant_contact_privacy_policy_content(); // phpcs:ignore -- XSS Ok. ?>
 					</div><!-- modal body -->
 					<div id="ctct-modal-footer-privacy" class="ctct-modal-footer ctct-modal-footer-privacy">
 						<a class="button button-blue ctct-connect" data-agree="true"><?php esc_html_e( 'Agree', 'constant-contact-forms' ); ?></a>

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -127,46 +127,6 @@ class ConstantContact_Settings {
 	}
 
 	/**
-	 * Add menu options page.
-	 *
-	 * @since 1.0.0
-	 */
-	public function add_options_page() {
-
-		$this->options_page = add_submenu_page(
-			'edit.php?post_type=ctct_forms',
-			esc_html__( 'Constant Contact Forms Settings', 'constant-contact-forms' ),
-			esc_html__( 'Settings', 'constant-contact-forms' ),
-			'manage_options',
-			$this->key,
-			[ $this, 'admin_page_display' ]
-		);
-
-		// Include CMB CSS in the head to avoid FOUC.
-		add_action( "admin_print_styles-{$this->options_page}", [ 'CMB2_hookup', 'enqueue_cmb_css' ] );
-	}
-
-	/**
-	 * Admin page markup. Mostly handled by CMB2.
-	 *
-	 * @since 1.0.0
-	 */
-	public function admin_page_display() {
-		?>
-		<div class="wrap cmb2-options-page <?php echo esc_attr( $this->key ); ?>">
-			<h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
-			<?php
-			if ( function_exists( 'cmb2_metabox_form' ) ) {
-				cmb2_metabox_form( $this->metabox_id, $this->key );
-			}
-
-			$this->plugin->check->maybe_display_debug_info();
-			?>
-		</div>
-		<?php
-	}
-
-	/**
 	 * Are we on the settings page?
 	 *
 	 * @since 1.0.0

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -34,6 +34,17 @@ class ConstantContact_Settings {
 	private $metabox_id = 'ctct_option_metabox_settings';
 
 	/**
+	 * Settings page metabox titles by id.
+	 *
+	 * @since NEXT
+	 * @var array
+	 */
+	private $metabox_titles = [
+		'general'   => 'General',
+		'recaptcha' => 'reCaptcha',
+	];
+
+	/**
 	 * Settings options page.
 	 *
 	 * @var string
@@ -145,28 +156,45 @@ class ConstantContact_Settings {
 	 * @since 1.0.0
 	 */
 	public function add_options_page_metaboxes() {
+		$this->register_fields_general();
+		$this->register_fields_recaptcha();
+	}
 
 
-		$cmb = new_cmb2_box( [
-			'id'           => $this->metabox_id,
+	/**
+	 * Get args for current CMB.
+	 *
+	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+	 * @since  NEXT
+	 *
+	 * @param  string $cmb_id Current CMB ID.
+	 * @return array          CMB args.
+	 */
+	protected function get_cmb_args( string $cmb_id ) : array {
+		return [
+			'id'           => "{$this->metabox_id}_{$cmb_id}",
 			'title'        => esc_html__( 'Constant Contact Forms Settings', 'constant-contact-forms' ),
+			'menu_title'   => esc_html__( 'Settings', 'constant-contact-forms' ),
 			'object_types' => [ 'options-page' ],
 			'option_key'   => 'ctct_options_settings',
-			'menu_title'   => esc_html__( 'Settings', 'constant-contact-forms' ),
-			'parent_slug'  => 'edit.php?post_type=ctct_forms',
-		] );
-
-		$this->do_lists_field( $cmb );
+			'parent_slug'  => add_query_arg( [
+				'post_type' => 'ctct_forms',
+				'page' => ( 'general' === $cmb_id ? false : $this->key ),
+			], 'edit.php' ),
+			'tab_group'    => 'ctct_options_settings',
+			'tab_title'    => $this->metabox_titles[ $cmb_id ],
+			'display_cb'   => [ $this, 'display_tabs' ],
+		];
 	}
 
 	/**
-	 * Helper to show our lists field for settings.
+	 * Register 'General' settings tab fields.
 	 *
-	 * @since 1.0.0
-	 *
-	 * @param object $cmb CMB fields object.
+	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+	 * @since  NEXT
 	 */
-	public function do_lists_field( $cmb ) {
+	protected function register_fields_general() {
+		$cmb = new_cmb2_box( $this->get_cmb_args( 'general' ) );
 
 		$cmb->add_field( [
 			'name' => esc_html__( 'Google Analytics&trade; tracking opt-in.', 'constant-contact-forms' ),
@@ -260,6 +288,16 @@ class ConstantContact_Settings {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Register 'Google reCAPTCHA' settings tab fields.
+	 *
+	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+	 * @since  NEXT
+	 */
+	protected function register_fields_recaptcha() {
+		$cmb = new_cmb2_box( $this->get_cmb_args( 'recaptcha' ) );
 
 		$before_recaptcha = sprintf(
 			'<hr/><h2>%s</h2>%s',
@@ -298,6 +336,16 @@ class ConstantContact_Settings {
 				'maxlength' => 50,
 			],
 		] );
+	}
+
+	/**
+	 * Helper to show our lists field for settings.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param object $cmb CMB fields object.
+	 */
+	public function do_lists_field( $cmb ) {
 
 		$before_global_css = sprintf(
 			'<hr /><h2>%s</h2>',

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -42,6 +42,9 @@ class ConstantContact_Settings {
 	private $metabox_titles = [
 		'general'   => 'General',
 		'recaptcha' => 'reCaptcha',
+		'form'      => 'Form',
+		'support'   => 'Support',
+		'spam'      => 'Spam',
 	];
 
 	/**
@@ -161,6 +164,9 @@ class ConstantContact_Settings {
 	public function add_options_page_metaboxes() {
 		$this->register_fields_general();
 		$this->register_fields_recaptcha();
+		$this->register_fields_form();
+		$this->register_fields_support();
+		$this->register_fields_spam();
 	}
 
 	/**
@@ -461,13 +467,13 @@ class ConstantContact_Settings {
 	}
 
 	/**
-	 * Helper to show our lists field for settings.
+	 * Register 'form' settings tab fields.
 	 *
-	 * @since 1.0.0
-	 *
-	 * @param object $cmb CMB fields object.
+	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+	 * @since  NEXT
 	 */
-	public function do_lists_field( $cmb ) {
+	protected function register_fields_form() {
+		$cmb = new_cmb2_box( $this->get_cmb_args( 'form' ) );
 
 		$before_global_css = sprintf(
 			'<hr /><h2>%s</h2>',
@@ -503,6 +509,16 @@ class ConstantContact_Settings {
 				'constant-contact-forms'
 			),
 		] );
+	}
+
+	/**
+	 * Register 'support' settings tab fields.
+	 *
+	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+	 * @since  NEXT
+	 */
+	protected function register_fields_support() {
+		$cmb = new_cmb2_box( $this->get_cmb_args( 'support' ) );
 
 		$before_debugging = sprintf(
 			'<hr/><h2>%s</h2>',
@@ -515,8 +531,37 @@ class ConstantContact_Settings {
 			'type'       => 'checkbox',
 			'before_row' => $before_debugging,
 		] );
+	}
 
-		$this->add_spam_error_fields( $cmb );
+	/**
+	 * Register 'spam' settings tab fields.
+	 *
+	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+	 * @since  NEXT
+	 */
+	protected function register_fields_spam() {
+		$cmb = new_cmb2_box( $this->get_cmb_args( 'spam' ) );
+
+		$description  = '<div class="description">';
+		$description .= esc_html__( 'This message displays when the plugin detects spam data.', 'constant-contact-forms' );
+		$description .= esc_html__( 'Note that this message may be overriden on a per-post basis.', 'constant-contact-forms' );
+		$description .= '</div>';
+
+		$before_message = sprintf(
+			'<hr/><h2>%s</h2>%s',
+			__( 'Suspected Bot Error Message', 'constant-contact-forms' ),
+			$description
+		);
+
+		$cmb->add_field(
+			[
+				'name'       => esc_html__( 'Error Message', 'constant-contact-forms' ),
+				'id'         => '_ctct_spam_error',
+				'type'       => 'text',
+				'before_row' => $before_message,
+				'default'    => $this->get_default_spam_error(),
+			]
+		);
 	}
 
 	/**
@@ -886,35 +931,6 @@ class ConstantContact_Settings {
 		$this->plugin->logging->create_log_folder();
 		$this->plugin->logging->create_log_index_file();
 		$this->plugin->logging->create_log_file();
-	}
-
-	/**
-	 * Adds a fieldset for controlling the spam error.
-	 *
-	 * @since 1.5.0
-	 * @param object $cmb An instance of the CMB2 object.
-	 */
-	private function add_spam_error_fields( $cmb ) {
-		$description  = '<div class="description">';
-		$description .= esc_html__( 'This message displays when the plugin detects spam data.', 'constant-contact-forms' );
-		$description .= esc_html__( 'Note that this message may be overriden on a per-post basis.', 'constant-contact-forms' );
-		$description .= '</div>';
-
-		$before_message = sprintf(
-			'<hr/><h2>%s</h2>%s',
-			__( 'Suspected Bot Error Message', 'constant-contact-forms' ),
-			$description
-		);
-
-		$cmb->add_field(
-			[
-				'name'       => esc_html__( 'Error Message', 'constant-contact-forms' ),
-				'id'         => '_ctct_spam_error',
-				'type'       => 'text',
-				'before_row' => $before_message,
-				'default'    => $this->get_default_spam_error(),
-			]
-		);
 	}
 
 	/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -62,9 +62,9 @@ class ConstantContact_Settings {
 
 		// Init cmb title property.
 		$this->metabox_titles = [
-			'general' => 'General',
-			'spam'    => 'Spam Control',
-			'support' => 'Support',
+			'general' => esc_html__( 'General', 'constant-contact-forms' ),
+			'spam'    => esc_html__( 'Spam Control' ),
+			'support' => esc_html__( 'Support' ),
 		];
 	}
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -57,7 +57,7 @@ class ConstantContact_Settings {
 	 */
 	public function __construct( $plugin ) {
 		$this->plugin = $plugin;
-		$this->hooks();
+		$this->register_hooks();
 	}
 
 	/**
@@ -65,19 +65,17 @@ class ConstantContact_Settings {
 	 *
 	 * @since 1.0.0
 	 */
-	public function hooks() {
-
-		add_action( 'cmb2_admin_init', [ $this, 'add_options_page_metabox' ] );
+	public function register_hooks() {
+		add_action( 'cmb2_admin_init', [ $this, 'add_options_page_metaboxes' ] );
 
 		add_filter( 'cmb2_override_option_get_' . $this->key, [ $this, 'get_override' ], 10, 2 );
-
 		add_filter( 'cmb2_override_option_save_' . $this->key, [ $this, 'update_override' ], 10, 2 );
+		add_action( "cmb2_save_options-page_fields_{$this->metabox_id}", [ $this, 'settings_notices' ], 10, 2 );
 
 		$this->inject_optin_form_hooks();
 
 		add_filter( 'preprocess_comment', [ $this, 'process_optin_comment_form' ] );
 		add_filter( 'authenticate', [ $this, 'process_optin_login_form' ], 10, 3 );
-
 		add_action( 'cmb2_save_field__ctct_logging', [ $this, 'maybe_init_logs' ], 10, 2 );
 		add_filter( 'ctct_custom_spam_message', [ $this, 'get_spam_error_message' ], 10, 2 );
 	}
@@ -88,7 +86,6 @@ class ConstantContact_Settings {
 	 * @since 1.0.0
 	 */
 	public function inject_optin_form_hooks() {
-
 		add_action( 'login_form', [ $this, 'optin_form_field_login' ] );
 		add_action( 'comment_form', [ $this, 'optin_form_field_comment' ] );
 
@@ -147,9 +144,8 @@ class ConstantContact_Settings {
 	 *
 	 * @since 1.0.0
 	 */
-	public function add_options_page_metabox() {
+	public function add_options_page_metaboxes() {
 
-		add_action( "cmb2_save_options-page_fields_{$this->metabox_id}", [ $this, 'settings_notices' ], 10, 2 );
 
 		$cmb = new_cmb2_box( [
 			'id'           => $this->metabox_id,

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -63,8 +63,8 @@ class ConstantContact_Settings {
 		// Init cmb title property.
 		$this->metabox_titles = [
 			'general' => esc_html__( 'General', 'constant-contact-forms' ),
-			'spam'    => esc_html__( 'Spam Control' ),
-			'support' => esc_html__( 'Support' ),
+			'spam'    => esc_html__( 'Spam Control', 'constant-contact-forms' ),
+			'support' => esc_html__( 'Support', 'constant-contact-forms' ),
 		];
 	}
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -277,7 +277,7 @@ class ConstantContact_Settings {
 	protected function get_current_tab() {
 		$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
 
-		return empty( $page ) ? "{$this->key}_general" : $page;
+		return ( empty( $page ) ? "{$this->key}_general" : $page );
 	}
 
 	/**
@@ -290,9 +290,7 @@ class ConstantContact_Settings {
 	 * @return string             URL to CMB tab.
 	 */
 	protected function get_tab_link( $option_key ) {
-		$menu_page_url = wp_specialchars_decode( menu_page_url( $option_key, false ) );
-
-		return $menu_page_url;
+		return wp_specialchars_decode( menu_page_url( $option_key, false ) );
 	}
 
 	/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -157,16 +157,22 @@ class ConstantContact_Settings {
 	}
 
 	/**
-	 * Add the options metabox to the array of metaboxes.
+	 * Add the options metaboxes to the array of metaboxes.
+	 *
+	 * Call corresponding method for each cmb key listed in $metabox_titles.
 	 *
 	 * @since 1.0.0
 	 */
 	public function add_options_page_metaboxes() {
-		$this->register_fields_general();
-		$this->register_fields_recaptcha();
-		$this->register_fields_form();
-		$this->register_fields_support();
-		$this->register_fields_spam();
+		foreach ( array_keys( $this->metabox_titles ) as $cmb_key ) {
+			$method = "register_fields_{$cmb_key}";
+
+			if ( ! method_exists( $this, $method ) ) {
+				continue;
+			}
+
+			$this->$method();
+		}
 	}
 
 	/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -827,11 +827,11 @@ class ConstantContact_Settings {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $test Something.
-	 * @param bool   $default Default to return.
+	 * @param string $deprecated Unused first param passed by CMB2 hook.
+	 * @param bool   $default    Default to return.
 	 * @return mixed Site option
 	 */
-	public function get_override( $test, $default = false ) {
+	public function get_override( $deprecated, $default = false ) {
 		return get_site_option( $this->key, $default );
 	}
 
@@ -840,11 +840,11 @@ class ConstantContact_Settings {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $ignore       Key.
+	 * @param string $deprecated   Unused first param passed by CMB2 hook.
 	 * @param mixed  $option_value Value to update to.
 	 * @return mixed Site option
 	 */
-	public function update_override( $ignore, $option_value ) {
+	public function update_override( $deprecated, $option_value ) {
 		return update_site_option( $this->key, $option_value );
 	}
 


### PR DESCRIPTION
### Link
Main options page: [https://[env]/wp-admin/edit.php?post_type=ctct_forms&page=ctct_options_settings_general](https://[env]/wp-admin/edit.php?post_type=ctct_forms&page=ctct_options_settings_general)

### Screenshots
![General Settings](https://i.imgur.com/wyHNSpO.png)
![Spam Control Settings](https://i.imgur.com/pul9BLG.png)
![Form Settings](https://i.imgur.com/nJ9YT1B.png)
![Support Settings](https://i.imgur.com/wNY4WgQ.png)

### Description
This update breaks the CtCt Forms Settings options page into separate tabs, using CMB2. All options are still saved to a single option key, `ctct_options_settings`.

### Testing
1. Use the link above (modify domain for the current environment) or navigate to wp-admin > Contact Form > Settings.
2. Navigate to each section by clicking its tab.
3. Change settings, save, and confirm settings are retained after load.