### PR TITLE
CC-43: Notify site owners of existing shortcode embeds for forms that get deleted

### DIFF
--- a/includes/class-notification-content.php
+++ b/includes/class-notification-content.php
@@ -187,6 +187,18 @@ class ConstantContact_Notification_Content {
 		);
 	}
 
+	/**
+	 * Admin notice regarding deleted forms.
+	 *
+	 * @since  NEXT
+	 *
+	 * @return string Deleted forms notice HTML.
+	 */
+	public static function deleted_forms() {
+		$option = get_option( ConstantContact_Notifications::$deleted_forms, [] );
+		return '';
+	}
+
 }
 
 /**
@@ -269,3 +281,22 @@ function constant_contact_exceptions_thrown( $notifications = [] ) {
 }
 
 add_filter( 'constant_contact_notifications', 'constant_contact_exceptions_thrown' );
+
+/**
+ * Add notification on form deletion if instances of that form appear as shortcodes or widgets.
+ *
+ * @since  NEXT
+ *
+ * @param  array $notifications Array of notifications to be shown.
+ * @return array                Array of notifications to be shown.
+ */
+function constant_contact_form_deleted( array $notifications = [] ) {
+	$notifications[] = [
+		'ID'         => 'deleted_forms',
+		'callback'   => [ 'ConstantContact_Notification_Content', 'deleted_forms' ],
+		'require_cb' => 'constant_contact_maybe_display_deleted_forms_notice',
+	];
+
+	return $notifications;
+}
+add_filter( 'constant_contact_notifications', 'constant_contact_form_deleted' );

--- a/includes/class-notification-content.php
+++ b/includes/class-notification-content.php
@@ -196,7 +196,14 @@ class ConstantContact_Notification_Content {
 	 */
 	public static function deleted_forms() {
 		$option = get_option( ConstantContact_Notifications::$deleted_forms, [] );
-		return '';
+
+		ob_start();
+		?>
+		<div class="admin-notice-message">
+			<p><?php esc_html_e( 'References to one or more deleted Constant Contact forms are still present on your site. Please review the list below and update or remove the references to avoid issues on your site.', 'constant-contact-forms' ); ?></p>
+		</div>
+		<?php
+		return ob_get_clean();
 	}
 
 }

--- a/includes/class-notification-content.php
+++ b/includes/class-notification-content.php
@@ -227,7 +227,8 @@ class ConstantContact_Notification_Content {
 			esc_html( $form_id )
 		);
 
-		$last_key = array_pop( array_keys( $references ) );
+		$reference_keys = array_keys( $references );
+		$last_key = array_pop( $reference_keys );
 
 		array_walk( $references, function( $value, $key, $last_key ) {
 			if ( 'post' === $value['type'] ) {

--- a/includes/class-notification-content.php
+++ b/includes/class-notification-content.php
@@ -219,7 +219,7 @@ class ConstantContact_Notification_Content {
 	 * @param  int   $form_id    Current form ID.
 	 * @param  array $references Current form references.
 	 */
-	protected static function display_deleted_form_reference_markup( int $form_id, array $references ) {
+	protected static function display_deleted_form_reference_markup( $form_id, array $references ) {
 		printf(
 			/* Translators: 1: label for form ID, 2: form ID, 3: references to specified form. */
 			'%1$s #%2$d: ',

--- a/includes/class-notification-content.php
+++ b/includes/class-notification-content.php
@@ -202,11 +202,9 @@ class ConstantContact_Notification_Content {
 		<div class="admin-notice-message">
 			<p><?php esc_html_e( 'References to one or more deleted Constant Contact forms are still present on your site. Please review the list below and update or remove the references to avoid issues on your site:', 'constant-contact-forms' ); ?></p>
 			<ul>
-				<?php
-				foreach ( $option as $form_id => $references ) {
-					self::display_deleted_form_post_markup( intval( $form_id ), $references );
-				}
-				?>
+				<?php foreach ( $option as $form_id => $references ) { ?>
+					<li><?php self::display_deleted_form_reference_markup( $form_id, $references ); ?></li>
+				<?php } ?>
 			</ul>
 		</div>
 		<?php
@@ -214,55 +212,47 @@ class ConstantContact_Notification_Content {
 	}
 
 	/**
-	 * Display deleted form HTML by form.
+	 * Display deleted form references HTML.
 	 *
 	 * @since  NEXT
 	 *
 	 * @param  int   $form_id    Current form ID.
 	 * @param  array $references Current form references.
-	 * @return void
 	 */
-	protected static function display_deleted_form_post_markup( int $form_id, array $references ) {
-		$post_ids   = isset( $references['posts'] ) ? $references['posts'] : [];
-		$widget_ids = isset( $references['widgets'] ) ? $references['widgets'] : [];
+	protected static function display_deleted_form_reference_markup( int $form_id, array $references ) {
+		printf(
+			/* Translators: 1: label for form ID, 2: form ID, 3: references to specified form. */
+			'%1$s #%2$d: ',
+			esc_html__( 'Form', 'constant-contact-forms' ),
+			esc_html( $form_id )
+		);
 
-		if ( empty( $post_ids ) && empty( $widget_ids ) ) {
-			return;
-		}
+		$last_key = array_pop( array_keys( $references ) );
 
-		if ( ! empty( $post_ids ) ) {
-			foreach ( $post_ids as $post_id => $post_type ) {
+		array_walk( $references, function( $value, $key, $last_key ) {
+			if ( 'post' === $value['type'] ) {
 				printf(
-					/* Translators: 1: URL to edit screen for current post, 2: post type singular label, 3: current post ID, 4: current post title. */
-					'<li><a href="%1$s">%2$s #%3$d: %4$s</a></li>',
-					esc_url( get_edit_post_link( $post_id ) ),
-					esc_html( get_post_type_object( $post_type )->labels->singular_name ),
-					esc_html( $post_id ),
-					esc_html( get_post( $post_id )->post_title )
+					/* Translators: 1: URL to edit screen for current post, 2: post type singular label, 3: current post ID, 4: separator between links. */
+					'<a href="%1$s">%2$s #%3$d</a>%4$s',
+					esc_url( $value['url'] ),
+					esc_html( $value['label'] ),
+					esc_html( $value['id'] ),
+					esc_html( $key === $last_key ? '' : ', ' )
+				);
+			} else if ( 'widget' === $value['type'] ) {
+				printf(
+					/* Translators: 1: URL to widgets admin screen, 2: current widget name, 3: generic widget text, 4: current widget title, 5: preposition, 6: specific sidebar name, 7: separator between links. */
+					'<a href="%1$s">%2$s %3$s "%4$s" %5$s %6$s</a>%7$s',
+					esc_url( $value['url'] ),
+					esc_html( $value['name'] ),
+					esc_html__( 'Widget titled', 'constant-contact-forms' ),
+					esc_html( $value['title'] ),
+					esc_html__( 'in', 'constant-contact-forms' ),
+					esc_html( $value['sidebar'] ),
+					esc_html( $key === $last_key ? '' : ', ' )
 				);
 			}
-		}
-
-		if ( ! empty( $widget_ids ) ) {
-			$sidebars = get_option( 'sidebars_widgets', [] );
-			global $wp_registered_sidebars, $wp_registered_widgets;
-
-			foreach ( $widget_ids as $widget_id ) {
-				$widget_id = "ctct_form-{$widget_id}";
-				$sidebar   = array_intersect_key( $wp_registered_sidebars, array_filter( $sidebars, function( $value ) use ( $widget_id ) {
-					return is_array( $value ) && in_array( $widget_id, $value );
-				} ) );
-
-				printf(
-					/* Translators: 1: URL to widgets admin screen, 2: current widget name, 3: generic widget text, 4: specific sidebar name. */
-					'<li><a href="%1$s">"%2$s" %3$s "%4$s"</a></li>',
-					esc_url( admin_url( 'widgets.php' ) ),
-					esc_html( $wp_registered_widgets[ $widget_id ]['name'] ),
-					esc_html__( 'Widget in', 'constant-contact-forms' ),
-					esc_html( array_shift( $sidebar )['name'] )
-				);
-			}
-		}
+		}, $last_key );
 	}
 }
 

--- a/includes/class-notifications.php
+++ b/includes/class-notifications.php
@@ -129,6 +129,9 @@ class ConstantContact_Notifications {
 		// Get our potentically dismissed notif ID.
 		$notif_id = $this->get_dismissal_id();
 
+		// Get current action to ensure dismissing on correct load.
+		$action = filter_input( INPUT_GET, 'action', FILTER_SANITIZE_STRING );
+
 		if ( $this->check_dismissal_nonce() && $notif_id ) {
 			$this->save_dismissed_notification( $notif_id );
 		}
@@ -264,7 +267,7 @@ class ConstantContact_Notifications {
 	 */
 	public function save_dismissed_notification( $key ) {
 		if ( 'deleted_forms' === $key ) {
-			return $this->delete_dismissed_option( $key );
+			$this->delete_dismissed_option( $key );
 		}
 		return $this->save_dismissed_option( $key, true );
 	}
@@ -433,13 +436,16 @@ class ConstantContact_Notifications {
 	/**
 	 * Fully remove a saved notification option from the database.
 	 *
+	 * Redirect to current page with dismissal query args removal to avoid potentially re-dismissing notices unintentionally.
+	 *
 	 * @since  NEXT
 	 *
 	 * @param  string $key Notice option key.
-	 * @return bool        Whether option key successfully deleted.
 	 */
 	protected function delete_dismissed_option( $key ) {
-		return delete_option( "ctct_{$key}" );
+		delete_option( "ctct_{$key}" );
+		wp_safe_redirect( remove_query_arg( [ 'ctct-dismiss-action', 'ctct-dismiss' ] ) );
+		exit;
 	}
 }
 

--- a/includes/class-notifications.php
+++ b/includes/class-notifications.php
@@ -263,6 +263,9 @@ class ConstantContact_Notifications {
 	 * @return bool If we updated correctly.
 	 */
 	public function save_dismissed_notification( $key ) {
+		if ( 'deleted_forms' === $key ) {
+			return $this->delete_dismissed_option( $key );
+		}
 		return $this->save_dismissed_option( $key, true );
 	}
 
@@ -425,6 +428,18 @@ class ConstantContact_Notifications {
 	public function get_activation_dismiss_url( $type ) {
 		$link = add_query_arg( [ 'ctct-dismiss-action' => esc_attr( $type ) ] );
 		return wp_nonce_url( $link, 'ctct-user-is-dismissing', 'ctct-dismiss' );
+	}
+
+	/**
+	 * Fully remove a saved notification option from the database.
+	 *
+	 * @since  NEXT
+	 *
+	 * @param  string $key Notice option key.
+	 * @return bool        Whether option key successfully deleted.
+	 */
+	protected function delete_dismissed_option( $key ) {
+		return delete_option( "ctct_{$key}" );
 	}
 }
 

--- a/includes/class-notifications.php
+++ b/includes/class-notifications.php
@@ -59,7 +59,7 @@ class ConstantContact_Notifications {
 	 *
 	 * @var string
 	 */
-	public static $deleted_forms = 'ctct-deleted-forms';
+	public static $deleted_forms = 'ctct_deleted_forms';
 
 	/**
 	 * Constructor.

--- a/includes/class-notifications.php
+++ b/includes/class-notifications.php
@@ -53,6 +53,15 @@ class ConstantContact_Notifications {
 	public static $reviewed_option = 'ctct-reviewed';
 
 	/**
+	 * Option name for deleted forms, containing IDs for post and widget instances of forms.
+	 *
+	 * @since NEXT
+	 *
+	 * @var string
+	 */
+	public static $deleted_forms = 'ctct-deleted-forms';
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.0.0

--- a/includes/class-uninstall.php
+++ b/includes/class-uninstall.php
@@ -80,6 +80,7 @@ class ConstantContact_Uninstall {
 			ConstantContact_Notifications::$dismissed_notices_option,
 			ConstantContact_Notifications::$review_dismissed_option,
 			ConstantContact_Notifications::$reviewed_option,
+			ConstantContact_Notifications::$deleted_forms,
 		];
 
 		/**

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -796,6 +796,27 @@ function constant_contact_check_for_affected_forms_on_trash( int $form_id ) {
 add_action( 'trash_ctct_forms', 'constant_contact_check_for_affected_forms_on_trash' );
 
 /**
+ * Remove saved references to deleted form if restored from trash.
+ *
+ * @since  NEXT
+ *
+ * @param  int $post_id Post ID being restored.
+ * @return void
+ */
+function constant_contact_remove_form_references_on_restore( int $post_id ) {
+	if ( 'ctct_forms' !== get_post_type( $post_id ) ) {
+		return;
+	}
+
+	$option = get_option( ConstantContact_Notifications::$deleted_forms, [] );
+
+	unset( $option[ $post_id ] );
+
+	update_option( ConstantContact_Notifications::$deleted_forms, $option );
+}
+add_action( 'untrashed_post', 'constant_contact_remove_form_references_on_restore' );
+
+/**
  * Determine whether to display the deleted forms notice in admin.
  *
  * @since  NEXT

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -693,14 +693,13 @@ function constant_contact_find_post_content_shortcodes( int $post_id ) {
 	$post_id_like_single = $wpdb->esc_like( "form='{$post_id}'" );
 	$post_id_like_double = $wpdb->esc_like( "form=\"{$post_id}\"" );
 	$posts               = $wpdb->get_results( $wpdb->prepare(
-		"SELECT ID FROM {$wpdb->posts} WHERE (`post_content` LIKE %s OR `post_content` LIKE %s) and `post_status` = %s ",
+		"SELECT ID, post_type FROM {$wpdb->posts} WHERE (`post_content` LIKE %s OR `post_content` LIKE %s) AND `post_status` = %s ORDER BY post_type ASC",
 		"%{$shortcode_like}%{$post_id_like_single}%",
 		"%{$shortcode_like}%{$post_id_like_double}%",
 		'publish'
 	), ARRAY_A );
 
-	$ids = wp_list_pluck( $posts, 'ID' );
-	return array_map( 'absint', $ids );
+	return wp_list_pluck( $posts, 'post_type', 'ID' );
 }
 
 /**

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -706,14 +706,16 @@ function constant_contact_find_post_content_shortcodes( int $post_id ) {
 /**
  * Check our widgets for existing forms.
  *
- * @since NEXT
- * @return array
+ * @since  NEXT
+ *
+ * @param  int $post_id Post ID being trashed.
+ * @return array        Array of form widget IDs containing the form ID.
  */
-function constant_contact_find_widgets() {
+function constant_contact_find_widgets( int $post_id ) {
 	$widgets = get_option( 'widget_ctct_form' );
-
-	$ids = array_filter( wp_list_pluck( $widgets, 'ctct_form_id' ) );
-	return array_map( 'absint', $ids );
+	return array_keys( array_filter( array_map( 'absint', wp_list_pluck( $widgets, 'ctct_form_id' ) ), function( $value ) use ( $post_id ) {
+		return $value === $post_id;
+	} ) );
 }
 
 /**
@@ -722,12 +724,9 @@ function constant_contact_find_widgets() {
  * @since NEXT
  * @param int $post_id Post ID being trashed.
  */
-	$widgets_with_form = constant_contact_find_widgets();
-
-	$affected_posts_exist   = in_array( $post_id, $posts_with_form, true );
-	$affected_widgets_exist = in_array( $post_id, $widgets_with_form, true );
 function constant_contact_check_for_affected_forms_on_trash( int $post_id ) {
 	$post_ids   = constant_contact_find_post_content_shortcodes( $post_id );
+	$widget_ids = constant_contact_find_widgets( $post_id );
 
 	// @todo Figure out how we want to notify at this point.
 }

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -733,3 +733,14 @@ function constant_contact_check_for_affected_forms_on_trash( int $post_id ) {
 	update_option( ConstantContact_Notifications::$deleted_forms, $option );
 }
 add_action( 'trash_ctct_forms', 'constant_contact_check_for_affected_forms_on_trash' );
+
+/**
+ * Determine whether to display the deleted forms notice in admin.
+ *
+ * @since  NEXT
+ *
+ * @return bool Whether to display the deleted forms notice.
+ */
+function constant_contact_maybe_display_deleted_forms_notice() {
+	return ! empty( get_option( ConstantContact_Notifications::$deleted_forms, [] ) );
+}

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -686,7 +686,7 @@ function constant_contact_location_and_line( $location = '', $line = '' ) {
  * @param  int $form_id Form ID.
  * @return array        Array of posts containing the form ID.
  */
-function constant_contact_get_posts_by_form( int $form_id ) {
+function constant_contact_get_posts_by_form( $form_id ) {
 	global $wpdb;
 
 	$shortcode_like      = $wpdb->esc_like( '[ctct' );
@@ -719,7 +719,7 @@ function constant_contact_get_posts_by_form( int $form_id ) {
  * @param  int $form_id Form ID.
  * @return array        Array of widgets containing the form ID.
  */
-function constant_contact_get_widgets_by_form( int $form_id ) {
+function constant_contact_get_widgets_by_form( $form_id ) {
 	$return = [];
 
 	foreach ( [ 'ctct_form', 'text' ] as $widget_type ) {
@@ -755,7 +755,7 @@ function constant_contact_get_widgets_by_form( int $form_id ) {
  * @param  string $key   Current widget key.
  * @param  string $type  Type of widget.
  */
-function constant_contact_walk_widget_references( array &$value, string $key, string $type ) {
+function constant_contact_walk_widget_references( array &$value, $key, $type ) {
 	global $wp_registered_sidebars, $wp_registered_widgets;
 
 	$widget_id  = "{$type}-{$key}";
@@ -780,7 +780,7 @@ function constant_contact_walk_widget_references( array &$value, string $key, st
  * @param int $form_id Form ID being trashed.
  * @return void
  */
-function constant_contact_check_for_affected_forms_on_trash( int $form_id ) {
+function constant_contact_check_for_affected_forms_on_trash( $form_id ) {
 	$option             = get_option( ConstantContact_Notifications::$deleted_forms, [] );
 	$option[ $form_id ] = array_filter( array_merge(
 		constant_contact_get_posts_by_form( $form_id ),
@@ -803,7 +803,7 @@ add_action( 'trash_ctct_forms', 'constant_contact_check_for_affected_forms_on_tr
  * @param  int $post_id Post ID being restored.
  * @return void
  */
-function constant_contact_remove_form_references_on_restore( int $post_id ) {
+function constant_contact_remove_form_references_on_restore( $post_id ) {
 	if ( 'ctct_forms' !== get_post_type( $post_id ) ) {
 		return;
 	}

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -724,9 +724,12 @@ function constant_contact_find_widgets( int $post_id ) {
  * @param int $post_id Post ID being trashed.
  */
 function constant_contact_check_for_affected_forms_on_trash( int $post_id ) {
-	$post_ids   = constant_contact_find_post_content_shortcodes( $post_id );
-	$widget_ids = constant_contact_find_widgets( $post_id );
+	$option             = get_option( ConstantContact_Notifications::$deleted_forms, [] );
+	$option[ $post_id ] = [
+		'posts'   => constant_contact_find_post_content_shortcodes( $post_id ),
+		'widgets' => constant_contact_find_widgets( $post_id ),
+	];
 
-	// @todo Figure out how we want to notify at this point.
+	update_option( ConstantContact_Notifications::$deleted_forms, $option );
 }
 add_action( 'trash_ctct_forms', 'constant_contact_check_for_affected_forms_on_trash' );


### PR DESCRIPTION
[CC-43](https://webdevstudios.atlassian.net/browse/CC-43)

### Description ###
- Upon form deletion: add all references to form in both posts (all post types with status "publish") and widgets (Constant Contact Form and Text widgets) to new `ctct_deleted_forms` option.
- Upon form restore: remove all references to restored form from `ctct_deleted_forms` option.
- On admin page load: if any deleted form references exist in `ctct_deleted_forms` option, display dismissible notice with links to each reference for each form.
- Upon dismissing notice: remove `ctct_deleted_forms` option.

### Testing Steps ###
- Create a form and place a shortcode in a post or widget, or add a CC form widget with a reference to that form.
- Delete form and confirm notice appears listing references.
- Restore form and confirm notice disappears.
- Repeat the above but with multiple forms.
  - Form delete/restore functionality should be the same whether one or multiple forms affected at once.
  - If notice displays references to more than one form and one of those forms is restored from the trash, only references to the restored form should disappear from the notice but the notice should still remain with references to the other (still trashed) forms.
- Delete a form, dismiss the notice, then delete another form and confirm the new notice does not include references to the previously deleted form(s).

### Screenshots ###
![screenshot](https://i.imgur.com/YYDL0Im.png)