### PR TITLE
CC-128: Change logging location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+= NEXT =
+* Updated: Moved logging directory to `uploads`. Some installs may encounter an error writing to the new directory, in which case deactivating then re-activating logging should fix the issue.
+
 = 1.3.7 =
 * Added: Logging functionality to help aid with debugging and the plugin not working as needed or expected.
 * Added: Passed form ID to filters related to including labels for custom fields.

--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -376,7 +376,6 @@ class Constant_Contact {
 		$this->basename        = plugin_basename( __FILE__ );
 		$this->url             = plugin_dir_url( __FILE__ );
 		$this->path            = plugin_dir_path( __FILE__ );
-		$this->logger_location = WP_CONTENT_DIR . '/ctct-logs/constant-contact-errors.log';
 
 		if ( ! $this->meets_php_requirements() ) {
 			add_action( 'admin_notices', array( $this, 'minimum_version' ) );
@@ -386,6 +385,9 @@ class Constant_Contact {
 		// Load our plugin and our libraries.
 		$this->plugin_classes();
 		$this->admin_plugin_classes();
+
+		// Set logging location.
+		$this->logger_location = $this->logging->get_logging_location();
 
 		// Include our helper functions function for end-users.
 		self::include_file( 'helper-functions', false );

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -391,4 +391,16 @@ class ConstantContact_Logging {
 
 		touch( $this->log_location_file );
 	}
+
+	/**
+	 * Retrieve logging file location.
+	 *
+	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+	 * @since  NEXT
+	 *
+	 * @return string Logging file location.
+	 */
+	public function get_logging_location() {
+		return $this->log_location_file;
+	}
 }

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -429,6 +429,16 @@ class ConstantContact_Logging {
 	}
 
 	/**
+	 * Remove current logging directory and files.
+	 *
+	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+	 * @since  NEXT
+	 */
+	public function delete_current_log_dir() {
+		$this->delete_log_dir( $this->log_location_dir );
+	}
+
+	/**
 	 * Helper function to remove logging directory.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -101,9 +101,12 @@ class ConstantContact_Logging {
 	public function __construct( $plugin ) {
 		$this->plugin            = $plugin;
 		$this->options_url       = admin_url( 'edit.php?post_type=ctct_forms&page=ctct_options_logging' );
-		$this->log_location_url  = content_url() . '/ctct-logs/constant-contact-errors.log';
-		$this->log_location_dir  = WP_CONTENT_DIR . '/ctct-logs';
-		$this->log_location_file = "{$this->log_location_dir}/constant-contact-errors.log";
+		$uploads_dir             = wp_upload_dir();
+		$log_file_dir            = 'ctct-logs';
+		$log_file_name           = 'constant-contact-errors.log';
+		$this->log_location_url  = "{$uploads_dir['baseurl']}/{$log_file_dir}/{$log_file_name}";
+		$this->log_location_dir  = "{$uploads_dir['basedir']}/{$log_file_dir}";
+		$this->log_location_file = "{$this->log_location_dir}/{$log_file_name}";
 		$this->log_index_file    = "{$this->log_location_dir}/index.php";
 
 		$this->hooks();

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -292,7 +292,9 @@ class ConstantContact_Logging {
 			unlink( $log_file );
 		}
 
-		$this->create_log_file();
+		if ( constant_contact_debugging_enabled() ) {
+			$this->create_log_file();
+		}
 
 		wp_redirect( $this->options_url );
 		exit();
@@ -348,13 +350,8 @@ class ConstantContact_Logging {
 	 * Create the log folder.
 	 *
 	 * @since 1.5.0
-	 * @return void
 	 */
 	public function create_log_folder() {
-		if ( ! constant_contact_debugging_enabled() ) {
-			return;
-		}
-
 		mkdir( $this->log_location_dir );
 		chmod( $this->log_location_dir, 0755 );
 	}
@@ -366,10 +363,6 @@ class ConstantContact_Logging {
 	 * @return void
 	 */
 	public function create_log_index_file() {
-		if ( ! constant_contact_debugging_enabled() ) {
-			return;
-		}
-
 		if ( ! is_writable( $this->log_location_dir ) ) {
 			return;
 		}
@@ -388,10 +381,6 @@ class ConstantContact_Logging {
 	 * @return void
 	 */
 	public function create_log_file() {
-		if ( ! constant_contact_debugging_enabled() ) {
-			return;
-		}
-
 		if ( ! is_writable( $this->log_location_dir ) ) {
 			return;
 		}

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -85,7 +85,7 @@ class ConstantContact_Settings {
 
 		add_filter( 'preprocess_comment', [ $this, 'process_optin_comment_form' ] );
 		add_filter( 'authenticate', [ $this, 'process_optin_login_form' ], 10, 3 );
-		add_action( 'cmb2_save_field__ctct_logging', [ $this, 'maybe_init_logs' ], 10, 2 );
+		add_action( 'cmb2_save_field__ctct_logging', [ $this, 'maybe_init_logs' ], 10, 3 );
 		add_filter( 'ctct_custom_spam_message', [ $this, 'get_spam_error_message' ], 10, 2 );
 	}
 
@@ -932,12 +932,17 @@ class ConstantContact_Settings {
 	 *
 	 * @since 1.5.0
 	 *
-	 * @param string $updated Whether or not we're updating.
-	 * @param string $action  Current action being performed.
+	 * @param string     $updated Whether or not we're updating.
+	 * @param string     $action  Current action being performed.
+	 * @param CMB2_Field $field   Current field object.
 	 * @return void
 	 */
-	public function maybe_init_logs( $updated, $action ) {
+	public function maybe_init_logs( $updated, $action, $field ) {
 		if ( 'updated' !== $action ) {
+			return;
+		}
+
+		if ( 'on' !== $field->value ) {
 			return;
 		}
 

--- a/includes/class-uninstall.php
+++ b/includes/class-uninstall.php
@@ -53,6 +53,7 @@ class ConstantContact_Uninstall {
 		$this->delete_options();
 		$this->delete_transients();
 		$this->delete_cron_hooks();
+		$this->delete_log_dir();
 	}
 
 	/**
@@ -171,5 +172,15 @@ class ConstantContact_Uninstall {
 		foreach ( $this->get_cron_hook_names() as $cron_hook_name ) {
 			wp_clear_scheduled_hook( $cron_hook_name );
 		}
+	}
+
+	/**
+	 * Delete logging directory.
+	 *
+	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+	 * @since  NEXT
+	 */
+	private function delete_log_dir() {
+		constant_contact()->logging->delete_current_log_dir();
 	}
 }


### PR DESCRIPTION
Ticket: [CC-128](https://webdevstudios.atlassian.net/browse/CC-128)

## Description

- Changes logging directory from `wp-content/ctct-logs` to `wp-content/uploads/ctct-logs`
- Removes old logging directory and files for versions <= 1.8.1.
- Removes new logging directory and files on uninstall.

## Testing

- (For local testing until we bump the actual plugin version) Change `constant-contact-forms.php` line 75 to be any higher version than 1.8.1.
- Ensure logging is enabled (Contact Form > Settings > Support > Enable logging...).
- Check local files to confirm old logging dir was removed and new dir was created.
- Uninstall plugin via admin to confirm new logging dir was removed (I tested on my local and it worked).