### PR TITLE
CC-143: Address issues with multiple form copies on single page

### DIFF
--- a/includes/class-display-shortcode.php
+++ b/includes/class-display-shortcode.php
@@ -110,7 +110,7 @@ class ConstantContact_Display_Shortcode {
 			'<div data-form-id="%1$s" id="ctct-form-wrapper-%2$s" class="ctct-form-wrapper">%3$s</div>',
 			esc_attr( $form_id ),
 			esc_attr( self::$form_instance ),
-			constant_contact()->display->form( $form_data, $form_id, $show_title )
+			constant_contact()->display->form( $form_data, $form_id, $show_title, self::$form_instance )
 		);
 
 		++self::$form_instance;

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -273,7 +273,7 @@ class ConstantContact_Display {
 		// if the status is success, then we sent the form correctly
 		// if the status is error, then we will re-show the form, but also
 		// with our error messages.
-		$response = constant_contact()->process_form->process_wrapper( $form_data, $form_id );
+		$response = constant_contact()->process_form->process_wrapper( $form_data, $form_id, $instance );
 
 		$old_values = isset( $response['values'] ) ? $response['values'] : '';
 		$req_errors = isset( $response['errors'] ) ? $response['errors'] : '';

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -245,14 +245,16 @@ class ConstantContact_Display {
 	/**
 	 * Main wrapper for getting our form display.
 	 *
-	 * @since 1.0.0
+	 * @since  1.0.0
+	 * @since  NEXT Added $instance param to help properly track multiple instances of the same form.
 	 *
-	 * @param array  $form_data   Array of form data.
-	 * @param string $form_id     Form ID.
-	 * @param bool   $show_title  Show title if true.
+	 * @param  array  $form_data  Array of form data.
+	 * @param  string $form_id    Form ID.
+	 * @param  bool   $show_title Show title if true.
+	 * @param  int    $instance   Current form instance.
 	 * @return string Form markup.
 	 */
-	public function form( $form_data, $form_id = '', $show_title = false ) {
+	public function form( $form_data, $form_id = '', $show_title = false, $instance = 0 ) {
 		if ( 'publish' !== get_post_status( $form_id ) ) {
 			return '';
 		}
@@ -356,6 +358,8 @@ class ConstantContact_Display {
 		$return .= $this->build_honeypot_field();
 
 		$return .= $this->add_verify_fields( $form_data );
+
+		$return .= $this->create_instance_field( $instance );
 
 		$return .= $this->build_timestamp();
 
@@ -1777,5 +1781,18 @@ class ConstantContact_Display {
 		 * @param string $value An `<abbr>` tag with an asterisk indicating required status.
 		 */
 		return apply_filters( 'constant_contact_required_label', '<abbr title="required">*</abbr>' );
+	}
+
+	/**
+	 * Add hidden input field to verify current instance of form.
+	 *
+	 * @since  NEXT
+	 *
+	 * @param  int $instance Current instance of form.
+	 * @return string HTML markup for instance field.
+	 */
+	protected function create_instance_field( $instance ) {
+		$instance = absint( $instance );
+		return $this->input( 'hidden', 'ctct-instance', 'ctct-instance', $instance, '', false, true );
 	}
 }

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -597,11 +597,12 @@ class ConstantContact_Process_Form {
 	 *
 	 * @throws Exception
 	 *
-	 * @param array      $form_data Form data to process.
-	 * @param string|int $form_id   Form ID being processed.
+	 * @param  array      $form_data Form data to process.
+	 * @param  string|int $form_id   Form ID being processed.
+	 * @param  int        $instance  Current form instance.
 	 * @return false|array
 	 */
-	public function process_wrapper( $form_data = [], $form_id = 0 ) {
+	public function process_wrapper( $form_data = [], $form_id = 0, $instance = 0 ) {
 
 		if ( empty( $_POST['ctct-id'] ) ) {
 			return false;
@@ -612,7 +613,14 @@ class ConstantContact_Process_Form {
 			return false;
 		}
 
-		$processed     = $this->process_form();
+		// Ensure calculated form instance matches POST form instance.
+		$posted_instance = absint( filter_input( INPUT_POST, 'ctct-instance', FILTER_SANITIZE_NUMBER_INT ) );
+
+		if ( $posted_instance !== $instance ) {
+			return false;
+		}
+
+		$processed     = $this->process_form( [], false );
 		$default_error = esc_html__( 'There was an error sending your form.', 'constant-contact-forms' );
 		$status        = false;
 


### PR DESCRIPTION
Ticket: [CC-143](https://webdevstudios.atlassian.net/browse/CC-143)

## Description ##

Adds hidden `ctct-instance` field to all forms. This is the unique index of the instance of the `ConstantContact_Display_Shortcode` class.
On submission, the `$_POST['ctct-instance']` field is checked against the current, passed `$instance` value and form processing aborts if these do not match.

## Testing ##

1. Add multiple instances of a single form on one page (I tested using both the shortcode and the Gutenberg block).
2. Ensure Google reCAPTCHA v2 is enabled.
3. Validate and submit one form.
4. Ensure the success message appears in place of the correct form (e.g., if the third form on the page was submitted, that form should display the success message instead of the success message defaulting to the first instance of the form).
5. Ensure "failed" reCAPTCHA messaging does not appear on the forms that were not submitted.