### PR TITLE
Hotfix php56 compat

### DIFF
--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -12,7 +12,7 @@
  * Plugin Name: Constant Contact Forms for WordPress
  * Plugin URI:  https://www.constantcontact.com
  * Description: Be a better marketer. All it takes is Constant Contact email marketing.
- * Version:     1.8.3
+ * Version:     1.8.3.1
  * Author:      Constant Contact
  * Author URI:  https://www.constantcontact.com/index?pn=miwordpress
  * License:     GPLv3
@@ -72,7 +72,7 @@ class Constant_Contact {
 	 * @since 1.0.0
 	 * @var string
 	 */
-	const VERSION = '1.8.3';
+	const VERSION = '1.8.3.1';
 
 	/**
 	 * URL of plugin directory.

--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -12,7 +12,7 @@
  * Plugin Name: Constant Contact Forms for WordPress
  * Plugin URI:  https://www.constantcontact.com
  * Description: Be a better marketer. All it takes is Constant Contact email marketing.
- * Version:     1.8.3.1
+ * Version:     1.8.4
  * Author:      Constant Contact
  * Author URI:  https://www.constantcontact.com/index?pn=miwordpress
  * License:     GPLv3
@@ -72,7 +72,7 @@ class Constant_Contact {
 	 * @since 1.0.0
 	 * @var string
 	 */
-	const VERSION = '1.8.3.1';
+	const VERSION = '1.8.4';
 
 	/**
 	 * URL of plugin directory.

--- a/includes/class-recaptcha-v2.php
+++ b/includes/class-recaptcha-v2.php
@@ -86,7 +86,7 @@ class ConstantContact_reCAPTCHA_v2 extends ConstantContact_reCAPTCHA {
 		$this->recaptcha_size = $size;
 	}
 
-	public function add_script_attributes( string $tag, string $handle ) {
+	public function add_script_attributes( $tag, $handle ) {
 		if ( 'recaptcha-lib-v2' !== $handle ) {
 			return $tag;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      constantcontact, webdevstudios, tw2113, znowebdev, ggwicz, ra
 Tags: capture, contacts, constant contact, constant contact form, constant contact newsletter, constant contact official, contact forms, email, form, forms, marketing, mobile, newsletter, opt-in, plugin, signup, subscribe, subscription, widget
 Requires at least: 5.2.0
 Tested up to:      5.4.1
-Stable tag:        1.8.3
+Stable tag:        1.8.3.1
 License:           GPLv3
 License URI:       http://www.gnu.org/licenses/gpl-3.0.html
 Requires PHP:      5.6
@@ -34,6 +34,9 @@ BONUS: If you have a Constant Contact account, all new email addresses that you 
 5. Basic Form
 
 == Changelog ==
+
+= 1.8.3.1 =
+* Fixed: Compatibility issue with PHP 5.6.
 
 = 1.8.3 =
 * Fixed: Potential compatibility issues around Gutenberg block.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      constantcontact, webdevstudios, tw2113, znowebdev, ggwicz, ra
 Tags: capture, contacts, constant contact, constant contact form, constant contact newsletter, constant contact official, contact forms, email, form, forms, marketing, mobile, newsletter, opt-in, plugin, signup, subscribe, subscription, widget
 Requires at least: 5.2.0
 Tested up to:      5.4.1
-Stable tag:        1.8.3.1
+Stable tag:        1.8.4
 License:           GPLv3
 License URI:       http://www.gnu.org/licenses/gpl-3.0.html
 Requires PHP:      5.6
@@ -35,7 +35,7 @@ BONUS: If you have a Constant Contact account, all new email addresses that you 
 
 == Changelog ==
 
-= 1.8.3.1 =
+= 1.8.4 =
 * Fixed: Compatibility issue with PHP 5.6.
 
 = 1.8.3 =


### PR DESCRIPTION
PHP5.6 doesn't have type hints available like we tried to use in one spot.