### PR TITLE
CC-158 use wp_mkdir_p and other debug log improvements

### DIFF
--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -549,7 +549,7 @@ class Constant_Contact {
 		}
 
 		// Create logging file and directory.
-		constant_contact()->logging->initialize_logging();
+		$this->logging->initialize_logging();
 	}
 
 	/**

--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -532,6 +532,24 @@ class Constant_Contact {
 	 */
 	public function init() {
 		load_plugin_textdomain( 'constant-contact-forms', false, dirname( $this->basename ) . '/languages/' );
+		$this->init_debug_log();
+	}
+
+	/**
+	 * Initialize debug log on init.
+	 *
+	 * @since NEXT
+	 *
+	 * @return void
+	 */
+	protected function init_debug_log() {
+
+		if ( ! constant_contact_debugging_enabled() ) {
+			return;
+		}
+
+		// Create logging file and directory.
+		constant_contact()->logging->initialize_logging();
 	}
 
 	/**

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -465,7 +465,7 @@ class ConstantContact_Logging {
 	 * @author Richard Aber <richard.aber@webdevstudios.com>
 	 * @since  NEXT
 	 */
-	public function iniitialize_logging() {
+	public function initialize_logging() {
 		$this->create_log_folder();
 		$this->create_log_index_file();
 		$this->create_log_file();

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -210,28 +210,19 @@ class ConstantContact_Logging {
 			<img class="ctct-logo" src="<?php echo esc_url( constant_contact()->url . 'assets/images/constant-contact-logo.png' ); ?>" alt="<?php echo esc_attr_x( 'Constant Contact logo', 'img alt text', 'constant-contact-forms' ); ?>">
 			<div class="ctct-body">
 				<?php
-				$contents     = '';
-				$log_location = $this->log_location_url;
 
-				if ( ! file_exists( constant_contact()->logger_location ) ) {
+				$contents = '';
 
-					if ( ! is_writable( constant_contact()->logger_location ) ) {
-						$contents .= sprintf(
-						/* Translators: placeholder holds the log location. */
-							esc_html__( 'We are not able to write to the %s file.', 'constant-contact-forms' ),
-							constant_contact()->logger_location
-						);
-					} else {
-						$contents .= esc_html__( 'No error log exists', 'constant-contact-forms' );
-					}
-				} elseif ( ! is_writable( constant_contact()->logger_location ) ) {
+				if ( ! file_exists( $this->log_location_file ) ) {
+					$contents .= esc_html__( 'No error log exists', 'constant-contact-forms' );
+				}
+
+				if ( ! is_writable( $this->log_location_file ) ) {
 					$contents .= sprintf(
 						/* Translators: placeholder holds the log location. */
 						esc_html__( 'We are not able to write to the %s file.', 'constant-contact-forms' ),
 						constant_contact()->logger_location
 					);
-				} else {
-					$contents .= $this->get_log_contents();
 				}
 				?>
 				<p><?php esc_html_e( 'Error log below can be used with support requests to help identify issues with Constant Contact Forms.', 'constant-contact-forms' ); ?></p>
@@ -239,18 +230,19 @@ class ConstantContact_Logging {
 				<textarea name="ctct_error_logs" id="ctct_error_logs" cols="80" rows="40" onclick="this.focus();this.select();" onfocus="this.focus();this.select();" readonly="readonly" aria-readonly="true"><?php echo esc_html( $contents ); ?></textarea>
 				<?php
 
-				if ( file_exists( constant_contact()->logger_location ) ) {
-					if ( ! empty( $contents ) && is_wp_error( $contents ) ) {
-						?>
-						<p><?php esc_html_e( 'Error log may still have content, even if an error is shown above. Please use the download link below.', 'constant-contact-forms' ); ?></p>
-						<?php
-					}
+				if ( is_file( $this->log_location_file ) && ! is_readable( $this->log_location_file ) ) {
+					?>
+					<p><?php esc_html_e( 'Error log may still have content, even if an error is shown above. Please use the download link below.', 'constant-contact-forms' ); ?></p>
+					<?php
+				}
+
+				if ( file_exists( $this->log_location_file ) ) {
 					?>
 					<p>
 						<?php
 							printf(
 								'<p><a href="%s" download>%s</a></p><p><a href="%s" id="deletelog">%s</a></p>',
-								esc_attr( $log_location ),
+								esc_attr( $this->log_location_url ),
 								esc_html__( 'Download logs', 'constant-contact-forms' ),
 								esc_attr(
 									wp_nonce_url(

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -224,6 +224,12 @@ class ConstantContact_Logging {
 						constant_contact()->logger_location
 					);
 				}
+
+				if ( is_file( $this->log_location_file ) && is_readable( $this->log_location_file ) ) {
+					// phpcs:ignore -- Not reading over network, it's on the filesystem.
+					$contents .= file_get_contents( $this->log_location_file );
+				}
+
 				?>
 				<p><?php esc_html_e( 'Error log below can be used with support requests to help identify issues with Constant Contact Forms.', 'constant-contact-forms' ); ?></p>
 				<p><?php esc_html_e( 'When available, you can share information by copying and pasting the content in the textarea, or by using the "Download logs" link at the end. Logs can be cleared by using the "Delete logs" link.', 'constant-contact-forms' ); ?></p>

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -304,7 +304,7 @@ class ConstantContact_Logging {
 			$this->create_log_file();
 		}
 
-		wp_redirect( $this->options_url );
+		wp_safe_redirect( $this->options_url );
 		exit();
 	}
 

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -458,4 +458,16 @@ class ConstantContact_Logging {
 		array_map( 'unlink', glob( "{$dir}/*" ) );
 		rmdir( $dir );
 	}
+
+	/**
+	 * Initialize Logging directories and files.
+	 *
+	 * @author Richard Aber <richard.aber@webdevstudios.com>
+	 * @since  NEXT
+	 */
+	public function iniitialize_logging() {
+		$this->create_log_folder();
+		$this->create_log_index_file();
+		$this->create_log_file();
+	}
 }

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -360,8 +360,7 @@ class ConstantContact_Logging {
 	 * @since 1.5.0
 	 */
 	public function create_log_folder() {
-		mkdir( $this->log_location_dir );
-		chmod( $this->log_location_dir, 0755 );
+		wp_mkdir_p( $this->log_location_dir );
 	}
 
 	/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -927,7 +927,7 @@ class ConstantContact_Settings {
 			return;
 		}
 
-		$this->plugin->logging->iniitialize_logging();
+		$this->plugin->logging->initialize_logging();
 	}
 
 	/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -927,9 +927,7 @@ class ConstantContact_Settings {
 			return;
 		}
 
-		$this->plugin->logging->create_log_folder();
-		$this->plugin->logging->create_log_index_file();
-		$this->plugin->logging->create_log_file();
+		$this->plugin->logging->iniitialize_logging();
 	}
 
 	/**

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -415,11 +415,7 @@ function constant_contact_maybe_log_it( $log_name, $error, $extra_data = '' ) {
 	$logging_file = constant_contact()->logger_location;
 
 	// Create logging file and directory if they don't exist.
-	if ( ! file_exists( $logging_file ) ) {
-		constant_contact()->logging->create_log_folder();
-		constant_contact()->logging->create_log_index_file();
-		constant_contact()->logging->create_log_file();
-	}
+	constant_contact()->logging->initialize_logging();
 
 	if ( ! is_writable( $logging_file ) ) {
 		return;


### PR DESCRIPTION
[CC-158](https://webdevstudios.atlassian.net/browse/CC-158)

In addition to using `wp_mkdir_p()` to create the logging directory, I also resolved an issue that I repeatedly saw in local testing where the logging admin page would say no log file had been created, when the file had indeed been created. Also simplified some of the error message logic on the logging admin page, and read the log file from the filesystem instead of remotely.

Use wp_mkdir_p to create log directory
Add a single method for logging initialization
Fix my typo
Initialize logging on init hook
Replace call to instance of self with $this
Use initialize_logging method
Prefer wp_safe_redirect
Simplify error messaging in admin_page_display
