### PR TITLE
CC-39: Force email notification on API request failure

### DIFF
--- a/includes/class-mail.php
+++ b/includes/class-mail.php
@@ -486,6 +486,11 @@ class ConstantContact_Mail {
 					esc_html__( 'NO (User did not select the Email Opt-in checkbox)', 'constant-contact-forms' ) . '<br/>' . esc_html__( "You can disable this under Form options. Email Opt-in isn't required to add subscribers into your account", 'constant-contact-forms' )
 				);
 			}
+		} else if ( isset( $submission_details['custom-reason'] ) && ! empty( $submission_details['custom-reason'] ) ) {
+			$content_notice .= sprintf(
+				$template,
+				esc_html( $submission_details['custom-reason'] )
+			);
 		}
 
 		return $content_notice;

--- a/includes/class-mail.php
+++ b/includes/class-mail.php
@@ -486,7 +486,7 @@ class ConstantContact_Mail {
 					esc_html__( 'NO (User did not select the Email Opt-in checkbox)', 'constant-contact-forms' ) . '<br/>' . esc_html__( "You can disable this under Form options. Email Opt-in isn't required to add subscribers into your account", 'constant-contact-forms' )
 				);
 			}
-		} else if ( isset( $submission_details['custom-reason'] ) && ! empty( $submission_details['custom-reason'] ) ) {
+		} elseif ( isset( $submission_details['custom-reason'] ) && ! empty( $submission_details['custom-reason'] ) ) {
 			$content_notice .= sprintf(
 				$template,
 				esc_html( $submission_details['custom-reason'] )

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -342,6 +342,12 @@ class ConstantContact_Process_Form {
 					$clean_values  = constant_contact()->process_form->clean_values( $return['values'] );
 					$pretty_values = constant_contact()->process_form->pretty_values( $clean_values );
 					$email_values  = constant_contact()->mail->format_values_for_email( $pretty_values, $orig_form_id );
+
+					constant_contact()->mail->mail( constant_contact()->mail->get_email( $orig_form_id ), $email_values, [
+						'form_id'         => $orig_form_id,
+						'submitted_email' => constant_contact()->mail->get_user_email_from_submission( $clean_values ),
+						'custom-reason'   => __( 'An error occurred while attempting Constant Contact API request.', 'constant-contact-forms' ),
+					], true );
 				}
 			} else {
 				constant_contact()->mail->submit_form_values( $return['values'], true );

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -335,7 +335,7 @@ class ConstantContact_Process_Form {
 
 			if ( constant_contact()->api->is_connected() && 'on' === $maybe_bypass ) {
 				constant_contact()->mail->submit_form_values( $return['values'] ); // Emails but doesn't schedule cron.
-				constant_contact()->mail->opt_in_user( $this->clean_values( $return['values'] ) );
+				$api_result = constant_contact()->mail->opt_in_user( $this->clean_values( $return['values'] ) );
 			} else {
 				constant_contact()->mail->submit_form_values( $return['values'], true );
 			}

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -336,6 +336,13 @@ class ConstantContact_Process_Form {
 			if ( constant_contact()->api->is_connected() && 'on' === $maybe_bypass ) {
 				constant_contact()->mail->submit_form_values( $return['values'] ); // Emails but doesn't schedule cron.
 				$api_result = constant_contact()->mail->opt_in_user( $this->clean_values( $return['values'] ) );
+
+				// Send email if API request fails.
+				if ( false === $api_result ) {
+					$clean_values  = constant_contact()->process_form->clean_values( $return['values'] );
+					$pretty_values = constant_contact()->process_form->pretty_values( $clean_values );
+					$email_values  = constant_contact()->mail->format_values_for_email( $pretty_values, $orig_form_id );
+				}
 			} else {
 				constant_contact()->mail->submit_form_values( $return['values'], true );
 			}


### PR DESCRIPTION
Ticket: [CC-39](https://webdevstudios.atlassian.net/browse/CC-39)

### Description ###

Forces email notification if request to add/update contact via CC API fails.
- Email mirrors a regular (non-forced) email notification on contact addition/update, with the added error message, "An error occurred while attempting Constant Contact API request."

### Steps to verify the solution ###

1. Check "Disable E-mail Notifications" under Contact Form > Settings.
2. Ensure the site is connected to a CC account.
3. Add a form to the site and select a list for the form.
4. Update `includes/class-api.php` line 547 to return false (to imitate a failed API request).
5. Attempt to submit the form on the frontend.
6. Check for email notification (via email logging plugin if local doesn't send emails) and confirm:
    - Email contains all data from form
    - Email contains custom error message