### PR TITLE
Chore/prep release 1.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+= 1.8.5 =
+* Added: Forced email notifications to admin when Constant Contact API request fails on attempted form submission.
+* Fixed: Addressed issues with plugin error logging and addressed false-positive error messaging.
+* Fixed: Cleaned up style minification task to allow for unminified version of stylesheet.
+* Updated: Updated support error messaging in admin to reference tab structure of plugin settings.
+
 = 1.8.4 =
 * Fixed: Compatibility issue with PHP 5.6.
 

--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -538,7 +538,7 @@ class Constant_Contact {
 	/**
 	 * Initialize debug log on init.
 	 *
-	 * @since NEXT
+	 * @since 1.8.5
 	 *
 	 * @return void
 	 */

--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -12,7 +12,7 @@
  * Plugin Name: Constant Contact Forms for WordPress
  * Plugin URI:  https://www.constantcontact.com
  * Description: Be a better marketer. All it takes is Constant Contact email marketing.
- * Version:     1.8.4
+ * Version:     1.8.5
  * Author:      Constant Contact
  * Author URI:  https://www.constantcontact.com/index?pn=miwordpress
  * License:     GPLv3
@@ -72,7 +72,7 @@ class Constant_Contact {
 	 * @since 1.0.0
 	 * @var string
 	 */
-	const VERSION = '1.8.4';
+	const VERSION = '1.8.5';
 
 	/**
 	 * URL of plugin directory.

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -461,7 +461,7 @@ class ConstantContact_Logging {
 	 * Initialize Logging directories and files.
 	 *
 	 * @author Richard Aber <richard.aber@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.5
 	 */
 	public function initialize_logging() {
 		$this->create_log_folder();

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -86,7 +86,7 @@ class ConstantContact_Logging {
 	/**
 	 * The logging directory name.
 	 *
-	 * @since NEXT
+	 * @since 1.8.2
 	 * @var   string
 	 */
 	protected $log_file_dir = 'ctct-logs';
@@ -401,7 +401,7 @@ class ConstantContact_Logging {
 	 * Retrieve logging file location.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.2
 	 *
 	 * @return string Logging file location.
 	 */
@@ -413,7 +413,7 @@ class ConstantContact_Logging {
 	 * Remove old logging directory and files for older plugin versions (<= 1.8.1).
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.2
 	 *
 	 * @return void
 	 */
@@ -429,7 +429,7 @@ class ConstantContact_Logging {
 	 * Remove current logging directory and files.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.2
 	 */
 	public function delete_current_log_dir() {
 		$this->delete_log_dir( $this->log_location_dir );
@@ -439,7 +439,7 @@ class ConstantContact_Logging {
 	 * Helper function to remove logging directory.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.2
 	 *
 	 * @return void
 	 */

--- a/includes/class-notification-content.php
+++ b/includes/class-notification-content.php
@@ -190,7 +190,7 @@ class ConstantContact_Notification_Content {
 	/**
 	 * Admin notice regarding deleted forms.
 	 *
-	 * @since  NEXT
+	 * @since  1.8.0
 	 *
 	 * @return string Deleted forms notice HTML.
 	 */
@@ -214,7 +214,7 @@ class ConstantContact_Notification_Content {
 	/**
 	 * Display deleted form references HTML.
 	 *
-	 * @since  NEXT
+	 * @since  1.8.0
 	 *
 	 * @param  int   $form_id    Current form ID.
 	 * @param  array $references Current form references.
@@ -341,7 +341,7 @@ add_filter( 'constant_contact_notifications', 'constant_contact_exceptions_throw
 /**
  * Add notification on form deletion if instances of that form appear as shortcodes or widgets.
  *
- * @since  NEXT
+ * @since  1.8.0
  *
  * @param  array $notifications Array of notifications to be shown.
  * @return array                Array of notifications to be shown.

--- a/includes/class-notifications.php
+++ b/includes/class-notifications.php
@@ -55,7 +55,7 @@ class ConstantContact_Notifications {
 	/**
 	 * Option name for deleted forms, containing IDs for post and widget instances of forms.
 	 *
-	 * @since NEXT
+	 * @since 1.8.0
 	 *
 	 * @var string
 	 */
@@ -438,7 +438,7 @@ class ConstantContact_Notifications {
 	 *
 	 * Redirect to current page with dismissal query args removal to avoid potentially re-dismissing notices unintentionally.
 	 *
-	 * @since  NEXT
+	 * @since  1.8.0
 	 *
 	 * @param  string $key Notice option key.
 	 */

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -36,7 +36,7 @@ class ConstantContact_Settings {
 	/**
 	 * Settings page metabox titles by id.
 	 *
-	 * @since NEXT
+	 * @since 1.8.0
 	 * @var   array|null
 	 */
 	private $metabox_titles;
@@ -93,7 +93,7 @@ class ConstantContact_Settings {
 	 * Add CMB2 hook overrides specific to individual metaboxes.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.0
 	 *
 	 * @return void
 	 */
@@ -189,7 +189,7 @@ class ConstantContact_Settings {
 	 * Remove secondary settings page menu items.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.0
 	 */
 	public function remove_extra_menu_items() {
 		foreach ( array_keys( $this->metabox_titles ) as $cmb_key ) {
@@ -207,7 +207,7 @@ class ConstantContact_Settings {
 	 * Override $plugin_page global to ensure "general" menu item active for other settings pages.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.0
 	 *
 	 * @param  string $file The parent file.
 	 * @return string       The parent file.
@@ -224,7 +224,7 @@ class ConstantContact_Settings {
 	 * Display options page with CMB2 tabs.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.0
 	 *
 	 * @param  CMB2_Options_Hookup $cmb_options The CMB2_Options_Hookup object.
 	 */
@@ -255,7 +255,7 @@ class ConstantContact_Settings {
 	 * Get all option tabs for navigation on CMB2 settings page.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.0
 	 *
 	 * @param  CMB2_Options_Hookup $cmb_options The CMB2_Options_Hookup object.
 	 * @return array                            Array of option tabs.
@@ -286,7 +286,7 @@ class ConstantContact_Settings {
 	 * Get currently selected tab.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.0
 	 *
 	 * @return string Current tab.
 	 */
@@ -300,7 +300,7 @@ class ConstantContact_Settings {
 	 * Get link to CMB tab.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.0
 	 *
 	 * @param  string $option_key CMB tab key.
 	 * @return string             URL to CMB tab.
@@ -313,7 +313,7 @@ class ConstantContact_Settings {
 	 * Get args for current CMB.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.0
 	 *
 	 * @param  string $cmb_id Current CMB ID.
 	 * @return array          CMB args.
@@ -336,7 +336,7 @@ class ConstantContact_Settings {
 	 * Register 'General' settings tab fields.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.0
 	 */
 	protected function register_fields_general() {
 		$cmb = new_cmb2_box( $this->get_cmb_args( 'general' ) );
@@ -480,7 +480,7 @@ class ConstantContact_Settings {
 	 * Register 'Spam Control' (incl. Google reCAPTCHA) settings tab fields.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.0
 	 */
 	protected function register_fields_spam() {
 		$cmb = new_cmb2_box( $this->get_cmb_args( 'spam' ) );
@@ -556,7 +556,7 @@ class ConstantContact_Settings {
 	 * Register 'Support' settings tab fields.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.0
 	 */
 	protected function register_fields_support() {
 		$cmb = new_cmb2_box( $this->get_cmb_args( 'support' ) );

--- a/includes/class-uninstall.php
+++ b/includes/class-uninstall.php
@@ -178,7 +178,7 @@ class ConstantContact_Uninstall {
 	 * Delete logging directory.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.8.2
 	 */
 	private function delete_log_dir() {
 		constant_contact()->logging->delete_current_log_dir();

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -686,7 +686,7 @@ function constant_contact_location_and_line( $location = '', $line = '' ) {
 /**
  * Get posts containing specified form ID.
  *
- * @since NEXT
+ * @since 1.8.0
  *
  * @param  int $form_id Form ID.
  * @return array        Array of posts containing the form ID.
@@ -719,7 +719,7 @@ function constant_contact_get_posts_by_form( $form_id ) {
 /**
  * Get links and info on widgets containing specified form ID.
  *
- * @since  NEXT
+ * @since  1.8.0
  *
  * @param  int $form_id Form ID.
  * @return array        Array of widgets containing the form ID.
@@ -754,7 +754,7 @@ function constant_contact_get_widgets_by_form( $form_id ) {
  * Walker callback for widget references of deleted forms.
  *
  * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
- * @since  NEXT
+ * @since  1.8.0
  *
  * @param  array  $value Array of current widget settings.
  * @param  string $key   Current widget key.
@@ -780,7 +780,7 @@ function constant_contact_walk_widget_references( array &$value, $key, $type ) {
 /**
  * Check for affected posts and widgets for the newly trashed form post type.
  *
- * @since NEXT
+ * @since 1.8.0
  *
  * @param int $form_id Form ID being trashed.
  * @return void
@@ -803,7 +803,7 @@ add_action( 'trash_ctct_forms', 'constant_contact_check_for_affected_forms_on_tr
 /**
  * Remove saved references to deleted form if restored from trash.
  *
- * @since  NEXT
+ * @since  1.8.0
  *
  * @param  int $post_id Post ID being restored.
  * @return void
@@ -824,7 +824,7 @@ add_action( 'untrashed_post', 'constant_contact_remove_form_references_on_restor
 /**
  * Determine whether to display the deleted forms notice in admin.
  *
- * @since  NEXT
+ * @since  1.8.0
  *
  * @return bool Whether to display the deleted forms notice.
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constant-contact-forms",
-  "version": "1.8.2",
+  "version": "1.8.5",
   "description": "",
   "main": "gulpfile.js",
   "dependencies": {},

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,6 @@ BONUS: If you have a Constant Contact account, all new email addresses that you 
 * Added: Forced email notifications to admin when Constant Contact API request fails on attempted form submission.
 * Fixed: Addressed issues with plugin error logging and addressed false-positive error messaging.
 * Fixed: Cleaned up style minification task to allow for unminified version of stylesheet.
-* Updated: Replaced usage of non-unique IDs on frontend form elements with classes.
 * Updated: Updated support error messaging in admin to reference tab structure of plugin settings.
 
 = 1.8.4 =

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      constantcontact, webdevstudios, tw2113, znowebdev, ggwicz, ra
 Tags: capture, contacts, constant contact, constant contact form, constant contact newsletter, constant contact official, contact forms, email, form, forms, marketing, mobile, newsletter, opt-in, plugin, signup, subscribe, subscription, widget
 Requires at least: 5.2.0
 Tested up to:      5.4.1
-Stable tag:        1.8.4
+Stable tag:        1.8.5
 License:           GPLv3
 License URI:       http://www.gnu.org/licenses/gpl-3.0.html
 Requires PHP:      5.6
@@ -35,7 +35,7 @@ BONUS: If you have a Constant Contact account, all new email addresses that you 
 
 == Changelog ==
 
-= NEXT =
+= 1.8.5 =
 * Added: Forced email notifications to admin when Constant Contact API request fails on attempted form submission.
 * Fixed: Addressed issues with plugin error logging and addressed false-positive error messaging.
 * Fixed: Cleaned up style minification task to allow for unminified version of stylesheet.


### PR DESCRIPTION
Looks like we had some leftover "@since NEXT" from previous releases. Matched their actual version number up against WPORG SVN tags.

Update stable tag and changelog version to 1.8.5
Remove "Replaced usage of non-unique IDs on frontend form elements" from 1.8.5 changelog in readme
Update version to 1.8.5 in package.json
Update plugin bootstrap header version field and constant to 1.8.5
Add 1.8.5 changes from readme.txt to CHANGELOG.md
Update @since NEXT for items that were previously released in 1.8.0
Update @since NEXT for items that were previously released in 1.8.2
Update @since NEXT for 1.8.5
