### PR TITLE
CC-179: Fix security linting errors

### DIFF
--- a/includes/class-cpts.php
+++ b/includes/class-cpts.php
@@ -179,8 +179,9 @@ class ConstantContact_CPTS {
 	 * @return array appended update messages with custom post types.
 	 */
 	public function post_updated_messages( $messages ) {
-
 		global $post;
+
+		$revision = filter_input( INPUT_GET, 'revision', FILTER_SANITIZE_NUMBER_INT );
 
 		$messages['ctct_lists'] = [
 			0  => '', // Unused. Messages start at index 1.
@@ -188,9 +189,9 @@ class ConstantContact_CPTS {
 			2  => __( 'Custom field updated.', 'constant-contact-forms' ),
 			3  => __( 'Custom field deleted.', 'constant-contact-forms' ),
 			4  => __( 'List updated.', 'constant-contact-forms' ),
-			5  => isset( $_GET['revision'] ) ?
+			5  => ! empty( $revision ) ?
 				/* translators: formatted revision timestamp. */
-				sprintf( __( 'List restored to revision from %s', 'constant-contact-forms' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) :
+				sprintf( __( 'List restored to revision from %s', 'constant-contact-forms' ), wp_post_revision_title( $revision, false ) ) :
 				false,
 			6  => __( 'List published.', 'constant-contact-forms' ),
 			7  => __( 'List saved.', 'constant-contact-forms' ),
@@ -207,9 +208,9 @@ class ConstantContact_CPTS {
 			2  => __( 'Custom field updated.', 'constant-contact-forms' ),
 			3  => __( 'Custom field deleted.', 'constant-contact-forms' ),
 			4  => __( 'Form updated.', 'constant-contact-forms' ),
-			5  => isset( $_GET['revision'] ) ?
+			5  => ! empty( $revision ) ?
 				/* translators: formatted revision timestamp. */
-				sprintf( __( 'Form restored to revision from %s', 'constant-contact-forms' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) :
+				sprintf( __( 'Form restored to revision from %s', 'constant-contact-forms' ), wp_post_revision_title( $revision, false ) ) :
 				false,
 			6  => sprintf(
 					/* translators: form shortcode. */

--- a/includes/class-display-shortcode.php
+++ b/includes/class-display-shortcode.php
@@ -127,7 +127,7 @@ class ConstantContact_Display_Shortcode {
 	 * @param bool $show_title If true, show the title.
 	 */
 	public function display_form( $form_id, $show_title = false ) {
-		echo $this->get_form( absint( $form_id ), $show_title ); // WPCS: XSS Ok.
+		echo $this->get_form( absint( $form_id ), $show_title ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- XSS OK.
 	}
 
 	/**

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -725,6 +725,7 @@ class ConstantContact_Display {
 		foreach ( $submitted_vals as $post ) {
 
 			if ( isset( $post['key'] ) && $post['key'] ) {
+				$post_map = filter_input( INPUT_POST, esc_attr( $map ), FILTER_SANITIZE_STRING );
 
 				if ( 'address' === $field['name'] ) {
 
@@ -733,23 +734,15 @@ class ConstantContact_Display {
 						$addr_key = explode( '___', $post['key'] );
 
 						if ( isset( $addr_key[0] ) && $addr_key[0] ) {
-
-							$post_key = '';
-
-							// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification -- Okay accessing of $_POST value.
-							if ( isset( $_POST[ esc_attr( $post['key'] ) ] ) ) {
-								$post_key = sanitize_text_field( wp_unslash( $_POST[ esc_attr( $post['key'] ) ] ) );
-							}
-							// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
+							$post_key = filter_input( INPUT_POST, esc_attr( $post['key'] ), FILTER_SANITIZE_STRING );
+							$post_key = empty( $post_key ) ? '' : sanitize_text_field( wp_unslash( $post_key ) );
 
 							$return[ esc_attr( $addr_key[0] ) ] = $post_key;
 						}
 					}
-				// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification -- Okay accessing of $_POST value.
-				} elseif ( $post['key'] === $map && isset( $_POST[ esc_attr( $map ) ] ) ) {
-					return sanitize_text_field( wp_unslash( $_POST[ esc_attr( $map ) ] ) );
+				} elseif ( $post['key'] === $map && ! empty( $post_map ) ) {
+					return sanitize_text_field( wp_unslash( $post_map ) );
 				}
-				// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
 			}
 		}
 

--- a/includes/class-gutenberg.php
+++ b/includes/class-gutenberg.php
@@ -85,7 +85,7 @@ class ConstantContact_Gutenberg {
 		}
 
 		ob_start();
-		echo constant_contact_get_form( absint( $attributes['selectedForm'] ) ); // WPCS: XSS OK.
+		echo constant_contact_get_form( absint( $attributes['selectedForm'] ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- XSS OK.
 		return ob_get_clean();
 	}
 }

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -232,8 +232,7 @@ class ConstantContact_Logging {
 				}
 
 				if ( is_file( $this->log_location_file ) && is_readable( $this->log_location_file ) ) {
-					// phpcs:ignore -- Not reading over network, it's on the filesystem.
-					$contents .= file_get_contents( $this->log_location_file );
+					$contents .= file_get_contents( $this->log_location_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Not reading over network, it's on the filesystem.
 				}
 
 				?>

--- a/includes/class-middleware.php
+++ b/includes/class-middleware.php
@@ -138,14 +138,17 @@ class ConstantContact_Middleware {
 	 * @return boolean Is valid?
 	 */
 	public function verify_and_save_access_token_return() {
+		$proof = filter_input( INPUT_GET, 'proof', FILTER_SANITIZE_STRING );
+		$token = filter_input( INPUT_GET, 'token', FILTER_SANITIZE_STRING );
+		$key   = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_STRING );
 
 		// If we get this, we'll want to start our process of
 		// verifying the proof that the middleware server gives us
 		// so that we can ignore any malicious entries that are sent to us
 		// Sanitize our expected data.
-		$proof = isset( $_GET['proof'] ) ? sanitize_text_field( wp_unslash( $_GET['proof'] ) ) : false;
-		$token = isset( $_GET['token'] ) ? sanitize_text_field( wp_unslash( $_GET['token'] ) ) : false;
-		$key   = isset( $_GET['key'] ) ? sanitize_text_field( wp_unslash( $_GET['key'] ) ) : false;
+		$proof = ! empty( $proof ) ? sanitize_text_field( $proof ) : false;
+		$token = ! empty( $token ) ? sanitize_text_field( $token ) : false;
+		$key   = ! empty( $key ) ? sanitize_text_field( $key ) : false;
 
 		// If we're missing any piece of data, we failed.
 		if ( ! $proof || ! $token || ! $key ) {

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -622,13 +622,14 @@ class ConstantContact_Process_Form {
 	 * @return false|array
 	 */
 	public function process_wrapper( $form_data = [], $form_id = 0, $instance = 0 ) {
+		$ctct_id = absint( filter_input( INPUT_POST, 'ctct-id', FILTER_SANITIZE_NUMBER_INT ) );
 
-		if ( empty( $_POST['ctct-id'] ) ) {
+		if ( empty( $ctct_id ) ) {
 			return false;
 		}
 
 		// @todo Utilize $form_data.
-		if ( isset( $_POST['ctct-id'] ) && absint( $_POST['ctct-id'] ) !== $form_id ) {
+		if ( $ctct_id !== $form_id ) {
 			return false;
 		}
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -897,7 +897,7 @@ class ConstantContact_Settings {
 						<h2 class="ctct-logo"><img src="<?php echo esc_url( constant_contact()->url . '/assets/images/constant-contact-logo.png' ); ?>" alt="<?php echo esc_attr_x( 'Constant Contact logo', 'img alt text', 'constant-contact-forms' ); ?>" /></h2>
 					</div>
 					<div class="ctct-modal-body ctct-privacy-modal-body">
-						<?php echo constant_contact_privacy_policy_content(); // phpcs:ignore -- XSS Ok. ?>
+						<?php echo constant_contact_privacy_policy_content(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- XSS OK. ?>
 					</div><!-- modal body -->
 					<div id="ctct-modal-footer-privacy" class="ctct-modal-footer ctct-modal-footer-privacy">
 						<a class="button button-blue ctct-connect" data-agree="true"><?php esc_html_e( 'Agree', 'constant-contact-forms' ); ?></a>

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -690,8 +690,9 @@ class ConstantContact_Settings {
 	 * @return array Comment form data.
 	 */
 	public function process_optin_comment_form( $comment_data ) {
+		$ctct_optin_list = filter_input( INPUT_POST, 'ctct_optin_list', FILTER_SANITIZE_NUMBER_INT );
 
-		if ( ! isset( $_POST['ctct_optin_list'] ) ) {
+		if ( empty( $ctct_optin_list ) ) {
 			return $comment_data;
 		}
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1,4 +1,4 @@
-<?php // phpcs:ignore -- Class name okay, PSR-4.
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- Class name okay, PSR-4.
 /**
  * Constant Contact Settings class.
  *

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -713,15 +713,14 @@ class ConstantContact_Settings {
 
 			$name    = isset( $comment_data['comment_author'] ) ? $comment_data['comment_author'] : '';
 			$website = isset( $comment_data['comment_author_url'] ) ? $comment_data['comment_author_url'] : '';
+			$list    = filter_input( INPUT_POST, 'ctct_optin_list', FILTER_SANITIZE_STRING );
 
-			if ( ! isset( $_POST['ctct_optin_list'] ) ) { // phpcs:ignore -- Okay accessing of $_POST.
+			if ( empty( $list ) ) {
 				return $comment_data;
 			}
 
-			$list = sanitize_text_field( wp_unslash( $_POST['ctct_optin_list'] ) ); // phpcs:ignore -- Okay accessing of $_POST.
-
 			$args = [
-				'list'       => $list,
+				'list'       => sanitize_text_field( wp_unslash( $list ) ),
 				'email'      => sanitize_email( $comment_data['comment_author_email'] ),
 				'first_name' => sanitize_text_field( $name ),
 				'last_name'  => '',
@@ -781,16 +780,16 @@ class ConstantContact_Settings {
 			$name = sanitize_text_field( $user_data->data->display_name );
 		}
 
-		if ( ! isset( $_POST['ctct_optin_list'] ) ) { // phpcs:ignore -- Okay accessing of $_POST.
+		$list = filter_input( INPUT_POST, 'ctct_optin_list', FILTER_SANITIZE_STRING );
+
+		if ( empty( $list ) ) {
 			return $user;
 		}
-
-		$list = sanitize_text_field( wp_unslash( $_POST['ctct_optin_list'] ) ); // phpcs:ignore -- Okay accessing of $_POST.
 
 		if ( $email ) {
 			$args = [
 				'email'      => $email,
-				'list'       => $list,
+				'list'       => sanitize_text_field( wp_unslash( $list ) ),
 				'first_name' => $name,
 				'last_name'  => '',
 			];

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -745,8 +745,9 @@ class ConstantContact_Settings {
 	 * @return object|array CTCT return API for contact or original $user array.
 	 */
 	public function process_optin_login_form( $user, $username, $password ) {
+		$ctct_optin_list = filter_input( INPUT_POST, 'ctct_optin_list', FILTER_SANITIZE_NUMBER_INT );
 
-		if ( ! isset( $_POST['ctct_optin_list'] ) ) {
+		if ( empty( $ctct_optin_list ) ) {
 			return $user;
 		}
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -216,7 +216,7 @@ class ConstantContact_Settings {
 	public function select_primary_menu_item( $file ) {
 		global $plugin_page;
 
-		$plugin_page = false !== strpos( $plugin_page, $this->key ) ? "{$this->key}_general" : $plugin_page; // phpcs:ignore -- Okay overriding of WP global
+		$plugin_page = false !== strpos( $plugin_page, $this->key ) ? "{$this->key}_general" : $plugin_page; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- OK overriding of WP global.
 
 		return $file;
 	}

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -690,7 +690,7 @@ class ConstantContact_Settings {
 	 * @return array Comment form data.
 	 */
 	public function process_optin_comment_form( $comment_data ) {
-		$ctct_optin_list = filter_input( INPUT_POST, 'ctct_optin_list', FILTER_SANITIZE_NUMBER_INT );
+		$ctct_optin_list = filter_input( INPUT_POST, 'ctct_optin_list', FILTER_SANITIZE_STRING );
 
 		if ( empty( $ctct_optin_list ) ) {
 			return $comment_data;
@@ -745,7 +745,7 @@ class ConstantContact_Settings {
 	 * @return object|array CTCT return API for contact or original $user array.
 	 */
 	public function process_optin_login_form( $user, $username, $password ) {
-		$ctct_optin_list = filter_input( INPUT_POST, 'ctct_optin_list', FILTER_SANITIZE_NUMBER_INT );
+		$ctct_optin_list = filter_input( INPUT_POST, 'ctct_optin_list', FILTER_SANITIZE_STRING );
 
 		if ( empty( $ctct_optin_list ) ) {
 			return $user;

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -160,10 +160,11 @@ class ConstantContact_Settings {
 	 * @return boolean If we are on the settings page or not.
 	 */
 	public function on_settings_page() {
-
 		global $pagenow;
 
-		return ( 'edit.php' === $pagenow && isset( $_GET['page'] ) && $this->key === $_GET['page'] ); // phpcs:ignore -- Okay accessing of $_GET.
+		$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
+
+		return ( 'edit.php' === $pagenow && ! empty( $page ) && $this->key === $page );
 	}
 
 	/**

--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -81,7 +81,7 @@ function constant_contact_wpspamshield_compatibility( $ignored_keys = [], $form_
 
 	// This will grab all of the keys from the global $_POST, and then assign
 	// the difference between that and our intended keys.
-	$bad_keys = array_diff( array_keys( $_POST ), $good_keys ); // WPCS: CSRF ok.
+	$bad_keys = array_diff( array_keys( $_POST ), $good_keys ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- CSRF OK.
 
 	// This will merge the passed ignored keys with our newly found bad keys,
 	// and then return all the unique values for our return value.

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -196,8 +196,8 @@ function constant_contact_maybe_display_exceptions_notice() {
  * @since 1.2.0
  */
 function constant_contact_optin_ajax_handler() {
-
-	$optin = filter_var( $_REQUEST['optin'], FILTER_SANITIZE_STRING );
+	$optin = filter_input( INPUT_GET, 'optin', FILTER_SANITIZE_STRING );
+	$optin = empty( $optin ) ? filter_input( INPUT_POST, 'optin', FILTER_SANITIZE_STRING ) : $optin;
 
 	if ( 'on' !== $optin ) {
 		wp_send_json_success( [ 'opted-in' => 'off' ] );

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -218,8 +218,9 @@ add_action( 'wp_ajax_constant_contact_optin_ajax_handler', 'constant_contact_opt
  * @since 1.2.0
  */
 function constant_contact_privacy_ajax_handler() {
+	$agreed = filter_input( INPUT_GET, 'privacy_agree', FILTER_SANITIZE_STRING );
+	$agreed = empty( $agreed ) ? filter_input( INPUT_POST, 'privacy_agree', FILTER_SANITIZE_STRING ) : $agreed;
 
-	$agreed = filter_var( $_REQUEST['privacy_agree'], FILTER_SANITIZE_STRING );
 	update_option( 'ctct_privacy_policy_status', $agreed );
 
 	wp_send_json_success( [ 'updated' => 'true' ] );

--- a/includes/widgets/contact-form-select.php
+++ b/includes/widgets/contact-form-select.php
@@ -112,16 +112,17 @@ class ConstantContactWidget extends WP_Widget {
 		$title           = trim( wp_strip_all_tags( $instance['ctct_title'] ) );
 		$form_id         = absint( $instance['ctct_form_id'] );
 		$show_form_title = ( ! empty( $instance['ctct_form_title'] ) ) ? 'true' : 'false';
-
-		echo $args['before_widget']; // WPCS: XSS Ok.
+		$widget          = $args['before_widget'];
 
 		if ( $title ) {
-			echo $args['before_title'] . esc_html( $title ) . $args['after_title']; // WPCS: XSS Ok.
+			$widget .= $args['before_title'] . esc_html( $title ) . $args['after_title'];
 		}
 
-		echo do_shortcode( sprintf( '[ctct form="%s" show_title="%s"]', $form_id, $show_form_title ) );
+		$widget .= do_shortcode( sprintf( '[ctct form="%s" show_title="%s"]', $form_id, $show_form_title ) );
 
-		echo $args['after_widget']; // WPCS: XSS Ok.
+		$widget .= $args['after_widget'];
+
+		echo $widget; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- XSS OK.
 	}
 
 	/**

--- a/includes/widgets/contact-form-select.php
+++ b/includes/widgets/contact-form-select.php
@@ -239,13 +239,14 @@ class ConstantContactWidget extends WP_Widget {
 					);
 				}
 			}
+
 			printf(
 				'<p><label for="%1$s">%2$s</label><select class="widefat" name="%3$s" id="%4$s">%5$s</select>',
 				esc_attr( $name ),
 				esc_html( $label_text ),
 				esc_attr( $name ),
 				esc_attr( $id ),
-				$selects
+				$selects // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- XSS OK.
 			);
 		}
 	}


### PR DESCRIPTION
Ticket: [CC-179](https://webdevstudios.atlassian.net/browse/CC-179)

### Description ###

Resolves `WordPress.Security.*` linting errors, explicitly mutes, or fixes ignore/disable comments.

```
PHP CODE SNIFFER VIOLATION SOURCE SUMMARY
--------------------------------------------------------------------------------
SOURCE                                                                     COUNT
--------------------------------------------------------------------------------
WordPress.Security.NonceVerification.Recommended                           12
WordPress.Security.NonceVerification.Missing                               9
WordPress.Security.EscapeOutput.DeprecatedWhitelistCommentFound            5
WordPress.Security.EscapeOutput.OutputNotEscaped                           1
WordPress.Security.NonceVerification.DeprecatedWhitelistCommentFound       1
```
