### PR TITLE
CC-180: Mute class/file name warnings

### DIFF
--- a/includes/class-recaptcha-v2.php
+++ b/includes/class-recaptcha-v2.php
@@ -11,6 +11,8 @@
  * phpcs:disable WebDevStudios.All.RequireAuthor -- Don't require author tag in docblocks.
  */
 
+// phpcs:disable PEAR.NamingConventions.ValidClassName.Invalid -- OK classname.
+
 /**
  * Class ConstantContact_reCAPTCHA_v2
  *

--- a/includes/class-recaptcha-v3.php
+++ b/includes/class-recaptcha-v3.php
@@ -11,6 +11,8 @@
  * phpcs:disable WebDevStudios.All.RequireAuthor -- Don't require author tag in docblocks.
  */
 
+// phpcs:disable PEAR.NamingConventions.ValidClassName.Invalid -- OK classname.
+
 /**
  * Class ConstantContact_reCAPTCHA_v3
  *

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -9,6 +9,8 @@
  * phpcs:disable WebDevStudios.All.RequireAuthor -- Don't require author tag in docblocks.
  */
 
+// phpcs:disable PEAR.NamingConventions.ValidClassName.Invalid -- OK classname.
+
 /**
  * Class ConstantContact_reCAPTCHA.
  *

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -53,4 +53,9 @@
 	<exclude-pattern>/tests/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
 
+	<!-- Ignore InvalidClassFileName warnings. -->
+	<rule ref="WordPress.Files.FileName">
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+	</rule>
+
 </ruleset>


### PR DESCRIPTION
Ticket: [CC-180](https://webdevstudios.atlassian.net/browse/CC-180)

### Description ###

Per concerns around changing class and file names at this time, we're leaving them as-is and explicitly muting warnings.

```
PHP CODE SNIFFER VIOLATION SOURCE SUMMARY
--------------------------------------------------------------------------------
SOURCE                                                                     COUNT
--------------------------------------------------------------------------------
WordPress.Files.FileName.InvalidClassFileName                              29
PEAR.NamingConventions.ValidClassName.Invalid                              3
```