### PR TITLE
CC-181: Address function warnings

### DIFF
--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -469,38 +469,40 @@ class ConstantContact_Process_Form {
 				'required'    => isset( $field['_ctct_required_field'] ) && $field['_ctct_required_field'],
 			];
 
+			$hashed_key = md5( serialize( $field_key ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- OK use of serialize().
+
 			switch ( $field['_ctct_map_select'] ) {
 				case 'address':
-					$return[ 'street_address___' . md5( serialize( $field_key ) ) ]                     = $field_key;
-					$return[ 'street_address___' . md5( serialize( $field_key ) ) ]['_ctct_map_select'] = 'street';
+					$return[ 'street_address___' . $hashed_key ]                     = $field_key;
+					$return[ 'street_address___' . $hashed_key ]['_ctct_map_select'] = 'street';
 
-					$return[ 'line_2_address___' . md5( serialize( $field_key ) ) ]                     = $field_key;
-					$return[ 'line_2_address___' . md5( serialize( $field_key ) ) ]['_ctct_map_select'] = 'line_2';
+					$return[ 'line_2_address___' . $hashed_key ]                     = $field_key;
+					$return[ 'line_2_address___' . $hashed_key ]['_ctct_map_select'] = 'line_2';
 
-					$return[ 'city_address___' . md5( serialize( $field_key ) ) ]                     = $field_key;
-					$return[ 'city_address___' . md5( serialize( $field_key ) ) ]['_ctct_map_select'] = 'city';
+					$return[ 'city_address___' . $hashed_key ]                     = $field_key;
+					$return[ 'city_address___' . $hashed_key ]['_ctct_map_select'] = 'city';
 
-					$return[ 'state_address___' . md5( serialize( $field_key ) ) ]                     = $field_key;
-					$return[ 'state_address___' . md5( serialize( $field_key ) ) ]['_ctct_map_select'] = 'state';
+					$return[ 'state_address___' . $hashed_key ]                     = $field_key;
+					$return[ 'state_address___' . $hashed_key ]['_ctct_map_select'] = 'state';
 
-					$return[ 'zip_address___' . md5( serialize( $field_key ) ) ]                     = $field_key;
-					$return[ 'zip_address___' . md5( serialize( $field_key ) ) ]['_ctct_map_select'] = 'zip';
+					$return[ 'zip_address___' . $hashed_key ]                     = $field_key;
+					$return[ 'zip_address___' . $hashed_key ]['_ctct_map_select'] = 'zip';
 
 					break;
 				case 'anniversery':
 				case 'birthday':
-					$return[ 'month___' . md5( serialize( $field_key ) ) ]                     = $field_key;
-					$return[ 'month___' . md5( serialize( $field_key ) ) ]['_ctct_map_select'] = 'month';
+					$return[ 'month___' . $hashed_key ]                     = $field_key;
+					$return[ 'month___' . $hashed_key ]['_ctct_map_select'] = 'month';
 
-					$return[ 'day___' . md5( serialize( $field_key ) ) ]                     = $field_key;
-					$return[ 'day___' . md5( serialize( $field_key ) ) ]['_ctct_map_select'] = 'day';
+					$return[ 'day___' . $hashed_key ]                     = $field_key;
+					$return[ 'day___' . $hashed_key ]['_ctct_map_select'] = 'day';
 
-					$return[ 'year___' . md5( serialize( $field_key ) ) ]                     = $field_key;
-					$return[ 'year___' . md5( serialize( $field_key ) ) ]['_ctct_map_select'] = 'year';
+					$return[ 'year___' . $hashed_key ]                     = $field_key;
+					$return[ 'year___' . $hashed_key ]['_ctct_map_select'] = 'year';
 
 					break;
 				default:
-					$return[ $field['_ctct_map_select'] . '___' . md5( serialize( $field_key ) ) ] = $field_key;
+					$return[ $field['_ctct_map_select'] . '___' . $hashed_key ] = $field_key;
 					break;
 			}
 		}

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -208,7 +208,7 @@ class ConstantContact_Process_Form {
 			$keys = $ctctrecaptcha->get_recaptcha_keys();
 			$ctctrecaptcha->set_recaptcha_class( new ReCaptcha( $keys['secret_key'], $method ) );
 
-			$ctctrecaptcha->recaptcha->setExpectedHostname( parse_url( home_url(), PHP_URL_HOST ) );
+			$ctctrecaptcha->recaptcha->setExpectedHostname( wp_parse_url( home_url(), PHP_URL_HOST ) );
 			if ( 'v3' === $ctctrecaptcha->get_recaptcha_version() ) {
 				/**
 				 * Filters the default float value for the score threshold.


### PR DESCRIPTION
Ticket: [CC-181](https://webdevstudios.atlassian.net/browse/CC-181)

### Description ###

Mutes warnings about `serialize()` as current use is just as a step to create a key hash.
Swaps `parse_url()` for `wp_parse_url()`.

Eliminates the following warnings:
```
PHP CODE SNIFFER VIOLATION SOURCE SUMMARY
--------------------------------------------------------------------------------
SOURCE                                                                     COUNT
--------------------------------------------------------------------------------
WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize                  17
WordPress.WP.AlternativeFunctions.parse_url_parse_url                      1
```