### PR TITLE
CC-177: Address remaining prefix warnings

### DIFF
--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -466,11 +466,6 @@ class Constant_Contact {
 
 		$this->load_libs();
 
-		// Our vendor files will do a check for ISSSL, so we want to set it to be that. See Guzzle for more info and usage of this.
-		if ( is_ssl() || ! defined( 'ISSSL' ) ) {
-			define( 'ISSSL', true );
-		}
-
 		add_filter( 'widget_text', 'do_shortcode' );
 		add_action( 'admin_enqueue_scripts', [ $this, 'register_admin_assets' ], 1 );
 		add_action( 'wp_enqueue_scripts', [ $this, 'register_front_assets' ], 1 );

--- a/includes/class-check.php
+++ b/includes/class-check.php
@@ -177,6 +177,8 @@ class ConstantContact_Check {
 		$sslverify     = version_compare( $wp_version, 4.0, '<' );
 		$doing_wp_cron = sprintf( '%.22F', microtime( true ) );
 
+		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Filters defined in WP Core.
+		/* This filter is documented in wp-includes/cron.php */
 		$cron_request = apply_filters( 'cron_request', [
 			'url'  => site_url( 'wp-cron.php?doing_wp_cron=' . $doing_wp_cron ),
 			'key'  => $doing_wp_cron,
@@ -186,6 +188,7 @@ class ConstantContact_Check {
 				'sslverify' => apply_filters( 'https_local_ssl_verify', $sslverify ),
 			],
 		] );
+		// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 		$cron_request['args']['blocking'] = true;
 


### PR DESCRIPTION
Ticket: [CC-177](https://webdevstudios.atlassian.net/browse/CC-177)

### Description ###

Removes old `ISSSL` constant and related block, as this is no longer used by the current vendor files.
Mutes phpcs warnings around usage of WP Core cron filters.