### PR TITLE
Update sprint/20.06-2 with changes from master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+= 1.8.6 =
+* Fixed: Removed invalid property being sent to the API, causing rejected requests.
+* Fixed: Failure to log API errors for support purposes.
+
 = 1.8.5 =
 * Added: Forced email notifications to admin when Constant Contact API request fails on attempted form submission.
 * Fixed: Addressed issues with plugin error logging and addressed false-positive error messaging.

--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -12,7 +12,7 @@
  * Plugin Name: Constant Contact Forms for WordPress
  * Plugin URI:  https://www.constantcontact.com
  * Description: Be a better marketer. All it takes is Constant Contact email marketing.
- * Version:     1.8.5
+ * Version:     1.8.6
  * Author:      Constant Contact
  * Author URI:  https://www.constantcontact.com/index?pn=miwordpress
  * License:     GPLv3
@@ -72,7 +72,7 @@ class Constant_Contact {
 	 * @since 1.0.0
 	 * @var string
 	 */
-	const VERSION = '1.8.5';
+	const VERSION = '1.8.6';
 
 	/**
 	 * URL of plugin directory.
@@ -522,7 +522,7 @@ class Constant_Contact {
 	 * @return bool
 	 */
 	public function meets_php_requirements() {
-		return version_compare( PHP_VERSION, '5.4.0', '>=' );
+		return version_compare( PHP_VERSION, '5.6.0', '>=' );
 	}
 
 	/**

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -818,8 +818,10 @@ class ConstantContact_API {
 					try {
 						$contact->$key = $value;
 					} catch ( Exception $e ) {
+						$errors = [];
 						$extra = constant_contact_location_and_line( __METHOD__, __LINE__ );
-						$this->log_errors( $extra . $e->getErrors() );
+						$errors[] = $extra . $e->getErrors();
+						$this->log_errors( $errors );
 						constant_contact_set_has_exceptions();
 						break;
 					}
@@ -845,10 +847,12 @@ class ConstantContact_API {
 	 * @param array $errors Errors from API.
 	 */
 	public function log_errors( $errors ) {
-
 		if ( is_array( $errors ) ) {
 			foreach ( $errors as $error ) {
-				$this->api_error_message( $error );
+				constant_contact_maybe_log_it(
+					'API',
+					$error
+				);
 			}
 		}
 	}
@@ -857,6 +861,7 @@ class ConstantContact_API {
 	 * Process api error response.
 	 *
 	 * @since 1.0.0
+	 * @since 1.8.6 Deprected
 	 *
 	 * @throws Exception
 	 *

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -293,6 +293,7 @@ class ConstantContact_Process_Form {
 			'ctct_usage_field',
 			'g-recaptcha-response',
 			'ctct_must_opt_in',
+			'ctct-instance',
 		], $orig_form_id );
 
 		foreach ( $data as $key => $value ) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      constantcontact, webdevstudios, tw2113, znowebdev, ggwicz, ra
 Tags: capture, contacts, constant contact, constant contact form, constant contact newsletter, constant contact official, contact forms, email, form, forms, marketing, mobile, newsletter, opt-in, plugin, signup, subscribe, subscription, widget
 Requires at least: 5.2.0
 Tested up to:      5.4.1
-Stable tag:        1.8.5
+Stable tag:        1.8.6
 License:           GPLv3
 License URI:       http://www.gnu.org/licenses/gpl-3.0.html
 Requires PHP:      5.6
@@ -34,6 +34,10 @@ BONUS: If you have a Constant Contact account, all new email addresses that you 
 5. Basic Form
 
 == Changelog ==
+
+= 1.8.6 =
+* Fixed: Removed invalid property being sent to the API, causing rejected requests.
+* Fixed: Failure to log API errors for support purposes.
 
 = 1.8.5 =
 * Added: Forced email notifications to admin when Constant Contact API request fails on attempted form submission.


### PR DESCRIPTION
A bugfix release, [1.8.6](https://github.com/WebDevStudios/constant-contact-forms/releases/tag/1.8.6), was merged into and tagged on master, from sprint/20.07 in PR #492, but the sprint/20.06-2 code hadn't yet shipped.

This PR updates sprint/20.06-2 with those changes from master in prep for release.