### PR TITLE
CC-178: Fix Prefix Mixmatches

### DIFF
--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -396,6 +396,9 @@ class Constant_Contact {
 
 		// Include compatibility fixes to address conflicts with other plug-ins.
 		self::include_file( 'compatibility', false );
+
+		// Include deprecated functions.
+		self::include_file( 'deprecated', false );
 	}
 
 	/**

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -980,8 +980,8 @@ class ConstantContact_API {
 		}
 
 		$disclosure = [
-			'name'    => empty( $account_info->organization_name ) ? ctct_get_settings_option( '_ctct_disclose_name', '' ) : $account_info->organization_name,
-			'address' => ctct_get_settings_option( '_ctct_disclose_address', '' ),
+			'name'    => empty( $account_info->organization_name ) ? constant_contact_get_option( '_ctct_disclose_name', '' ) : $account_info->organization_name,
+			'address' => constant_contact_get_option( '_ctct_disclose_address', '' ),
 		];
 
 		if ( empty( $disclosure['name'] ) ) {

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -386,14 +386,28 @@ class ConstantContact_Display {
 		$return .= '</form>';
 
 		ob_start();
+
 		/**
 		 * Fires after the end of the form tag.
+		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
 		 *
 		 * @since 1.4.0
 		 *
 		 * @param int $form_id Current form ID.
 		 */
-		do_action( 'ctct_after_form', $form_id ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Hookname is prefixed.
+		do_action_deprecated( 'ctct_after_form', [ $form_id ], 'NEXT', 'constant_contact_before_form' );
+
+		/**
+		 * Fires after the closing form tag.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param int $form_id Current form ID.
+		 */
+		do_action( 'constant_contact_after_form', $form_id );
+
 		$return .= ob_get_clean();
 
 		$return .= '<script type="text/javascript">';

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -328,14 +328,28 @@ class ConstantContact_Display {
 		}
 
 		ob_start();
+
 		/**
 		 * Fires before the start of the form tag.
+		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
 		 *
 		 * @since 1.4.0
 		 *
 		 * @param int $form_id Current form ID.
 		 */
-		do_action( 'ctct_before_form', $form_id ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Hookname is prefixed.
+		do_action_deprecated( 'ctct_before_form', [ $form_id ], 'NEXT', 'constant_contact_before_form' );
+
+		/**
+		 * Fires before the opening form tag.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param int $form_id Current form ID.
+		 */
+		do_action( 'constant_contact_before_form', $form_id );
+
 		$return .= ob_get_clean();
 
 		$return .= '<form class="' . esc_attr( $form_classes ) . '" id="' . $rf_id . '" ';

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -110,12 +110,12 @@ class ConstantContact_Display {
 
 		$global_form_css = [];
 
-		$global_form_classes = ctct_get_settings_option( '_ctct_form_custom_classes' );
+		$global_form_classes = constant_contact_get_option( '_ctct_form_custom_classes' );
 		if ( $global_form_classes ) {
 			$global_form_css['global_form_classes'] = $global_form_classes;
 		}
 
-		$global_label_placement = ctct_get_settings_option( 'ctct_form_label_placement' );
+		$global_label_placement = constant_contact_get_option( 'ctct_form_label_placement' );
 		if ( $global_label_placement ) {
 			$global_form_css['global_label_placement'] = $global_label_placement;
 		}
@@ -363,7 +363,7 @@ class ConstantContact_Display {
 		$return .= $this->build_form_fields( $form_data, $old_values, $req_errors );
 
 		if ( ! $disable_recaptcha && ConstantContact_reCAPTCHA::has_recaptcha_keys() ) {
-			$recaptcha_version = ctct_get_settings_option( '_ctct_recaptcha_version', '' );
+			$recaptcha_version = constant_contact_get_option( '_ctct_recaptcha_version', '' );
 			if ( 'v2' === $recaptcha_version ) {
 				$return .= $this->build_recaptcha( $form_id );
 			}

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -396,7 +396,7 @@ class ConstantContact_Display {
 		 *
 		 * @param int $form_id Current form ID.
 		 */
-		do_action_deprecated( 'ctct_after_form', [ $form_id ], 'NEXT', 'constant_contact_before_form' );
+		do_action_deprecated( 'ctct_after_form', [ $form_id ], 'NEXT', 'constant_contact_after_form' );
 
 		/**
 		 * Fires after the closing form tag.

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -689,12 +689,25 @@ class ConstantContact_Lists {
 		/**
 		 * Hook when a ctct list is deleted.
 		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
+		 *
 		 * @since 1.0.0
 		 *
 		 * @param integer $post_id Form list ID that was deleted.
 		 * @param integer $list_id Constant Contact list ID.
 		 */
-		do_action( 'ctct_delete_list', $post_id, $list_id ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Hookname is prefixed.
+		do_action_deprecated( 'ctct_delete_list', [ $post_id, $list_id ], 'NEXT', 'constant_contact_delete_list' );
+
+		/**
+		 * Fires when a list is deleted.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param  integer $post_id Form post ID.
+		 * @param  integer $list_id CTCT list ID.
+		 */
+		do_action( 'constant_contact_delete_list', $post_id, $list_id );
 
 		return $list;
 	}

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -348,11 +348,23 @@ class ConstantContact_Lists {
 		/**
 		 * Hook when a ctct list is updated.
 		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
+		 *
 		 * @since 1.0.0
 		 *
 		 * @param array $lists_to_insert CTCT returned list data.
 		 */
-		do_action( 'ctct_sync_lists', $lists_to_insert ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Hookname is prefixed.
+		do_action_deprecated( 'ctct_sync_lists', [ $lists_to_insert ], 'NEXT', 'constant_contact_sync_lists' );
+
+		/**
+		 * Fires after lists synced.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param  array $lists_to_insert Synced Constant Contact lists.
+		 */
+		do_action( 'constant_contact_sync_lists', $lists_to_insert );
 	}
 
 	/**

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -649,15 +649,11 @@ class ConstantContact_Lists {
 			]
 		);
 
-		/**
-		 * Hook when a ctct list is updated.
-		 *
-		 * @since 1.0.0
-		 * @param integer $post_id CPT post id.
-		 * @param integer $list_id Ctct list id.
-		 * @param array   $list    Ctct returned list data.
-		 */
-		do_action( 'ctct_update_list', $ctct_list->ID, $list_id, $list ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Hookname is prefixed.
+		/* This deprecated filter is documented in includes/class-lists.php */
+		do_action_deprecated( 'ctct_update_list', [ $ctct_list->ID, $list_id, $list ], 'NEXT', 'constant_contact_update_list' );
+
+		/* This filter is documented in includes/class-lists.php */
+		do_action( 'constant_contact_update_list', $ctct_list->ID, $list_id, $list );
 
 		return is_object( $list ) && isset( $list->id );
 	}

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -486,13 +486,27 @@ class ConstantContact_Lists {
 		/**
 		 * Hook when a ctct list is saved.
 		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
+		 *
 		 * @since 1.0.0
 		 *
 		 * @param integer $post_id CPT post id.
 		 * @param integer $list_id Ctct list id.
 		 * @param array   $list    Ctct returned list data.
 		 */
-		do_action( 'ctct_update_list', $ctct_list->ID, $list_id, $list ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Hookname is prefixed.
+		do_action_deprecated( 'ctct_update_list', [ $ctct_list->ID, $list_id, $list ], 'NEXT', 'constant_contact_update_list' );
+
+		/**
+		 * Fires when a list is updated.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param  integer $post_id Form post ID.
+		 * @param  integer $list_id CTCT list ID.
+		 * @param  array   $list    CTCT list data.
+		 */
+		do_action( 'constant_contact_update_list', $ctct_list->ID, $list_id, $list );
 
 		return is_object( $list ) && isset( $list->id );
 	}

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -166,7 +166,7 @@ class ConstantContact_Logging {
 	 */
 	public function add_options_page() {
 
-		$debugging_enabled = ctct_get_settings_option( '_ctct_logging', '' );
+		$debugging_enabled = constant_contact_get_option( '_ctct_logging', '' );
 
 		if ( 'on' !== $debugging_enabled ) {
 			return;

--- a/includes/class-mail.php
+++ b/includes/class-mail.php
@@ -65,7 +65,7 @@ class ConstantContact_Mail {
 
 		if ( $add_to_opt_in && constant_contact()->api->is_connected() ) {
 
-			$maybe_bypass = ctct_get_settings_option( '_ctct_bypass_cron', '' );
+			$maybe_bypass = constant_contact_get_option( '_ctct_bypass_cron', '' );
 
 			if ( 'on' !== $maybe_bypass ) {
 				/**

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -659,9 +659,10 @@ class ConstantContact_Process_Form {
 				/**
 				 * Filters the message for the successful processed form.
 				 *
+				 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
+				 *
 				 * @author Michael Beckwith <michael@webdevstudios.com>
 				 * @since  1.3.0
-				 * @deprecated deprecated since NEXT
 				 *
 				 * @param  string     $value Success message.
 				 * @param  string/int $form_id ID of the Constant Contact form being submitted to.

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -657,10 +657,11 @@ class ConstantContact_Process_Form {
 				 * Filters the message for the successful processed form.
 				 *
 				 * @author Michael Beckwith <michael@webdevstudios.com>
-				 * @since 1.3.0
+				 * @since  1.3.0
+				 * @deprecated deprecated since NEXT
 				 *
-				 * @param string     $value Success message.
-				 * @param string/int $form_id ID of the Constant Contact form being submitted to.
+				 * @param  string     $value Success message.
+				 * @param  string/int $form_id ID of the Constant Contact form being submitted to.
 				 */
 				$message = apply_filters( 'ctct_process_form_success', __( 'Your information has been submitted.', 'constant-contact-forms' ), $form_id ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Hookname is prefixed.
 				break;

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -108,7 +108,7 @@ class ConstantContact_Process_Form {
 			switch ( $status ) {
 
 				case 'success':
-					/** This filter is documented in includes/class-process-form.php */ // phpcs:ignore WebDevStudios.All.RequireAuthor.815dee87b802924681c29bc8a2de5f5271299785, WebDevStudios.All.RequireSince.13ca5a7b31977b85cc9bef96a61a278896b99d9c -- Filter documented elsewhere.
+					/* This filter is documented in includes/class-process-form.php */
 					$message = apply_filters( 'ctct_process_form_success', // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Hookname is prefixed.
 						__( 'Your information has been submitted.', 'constant-contact-forms' ),
 						(int) $json_data['ctct-id'] );

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -108,10 +108,13 @@ class ConstantContact_Process_Form {
 			switch ( $status ) {
 
 				case 'success':
+					$form_id = (int) $json_data['ctct-id'];
+
+					/* This deprecated filter is documented in includes/class-process-form.php */
+					$message = apply_filters_deprecated( 'ctct_process_form_success', [ __( 'Your information has been submitted.', 'constant-contact-forms' ), $form_id ], 'NEXT', 'constant_contact_process_form_success' );
+
 					/* This filter is documented in includes/class-process-form.php */
-					$message = apply_filters( 'ctct_process_form_success', // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Hookname is prefixed.
-						__( 'Your information has been submitted.', 'constant-contact-forms' ),
-						(int) $json_data['ctct-id'] );
+					$message = apply_filters( 'constant_contact_process_form_success', $message, $form_id );
 					break;
 
 				case 'error':

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -781,12 +781,26 @@ class ConstantContact_Process_Form {
 		/**
 		 * Filter the error message displayed for suspected non-humans.
 		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
+		 *
 		 * @author Michael Beckwith <michael@webdevstudios.com>
 		 * @since 1.5.0
 		 * @param string $error The error message dispalyed.
 		 * @param mixed  $post_id The ID of the current post.
 		 * @return string
 		 */
-		return apply_filters( 'ctct_custom_spam_message', $error, $post_id ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Hookname is prefixed.
+		$error = apply_filters_deprecated( 'ctct_custom_spam_message', [ $error, $post_id ], 'NEXT', 'constant_contact_custom_spam_message' );
+
+		/**
+		 * Filters error message for suspected spam entries.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param  string     $error   Error message.
+		 * @param  int|string $post_id Current post ID.
+		 * @return string              Error message.
+		 */
+		return apply_filters( 'constant_contact_custom_spam_message', $error, $post_id );
 	}
 }

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -213,17 +213,33 @@ class ConstantContact_Process_Form {
 
 			$ctctrecaptcha->recaptcha->setExpectedHostname( wp_parse_url( home_url(), PHP_URL_HOST ) );
 			if ( 'v3' === $ctctrecaptcha->get_recaptcha_version() ) {
+
 				/**
 				 * Filters the default float value for the score threshold.
 				 *
 				 * This value should be between 0.0 and 1.0.
+				 *
+				 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
 				 *
 				 * @since 1.7.0
 				 *
 				 * @param float  $value Threshold to require for submission approval.
 				 * @param string $value The ID of the form that was submitted.
 				 */
-				$threshold = (float) apply_filters( 'ctct_recaptcha_threshold', 0.5, $data['ctct-id'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Hookname is prefixed.
+				$threshold = apply_filters_deprecated( 'ctct_recaptcha_threshold', [ 0.5, $data['ctct-id'] ], 'NEXT', 'constant_contact_recaptcha_threshold' );
+
+				/**
+				 * Filters the default float value for the score threshold.
+				 *
+				 * This value should be between 0.0 and 1.0.
+				 *
+				 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+				 * @since  NEXT
+				 *
+				 * @param  float  $value Required threshold value.
+				 * @param  string $value Form ID.
+				 */
+				$threshold = (float) apply_filters( 'constant_contact_recaptcha_threshold', 0.5, $data['ctct-id'] );
 
 				$ctctrecaptcha->recaptcha->setScoreThreshold( $threshold );
 				$ctctrecaptcha->recaptcha->setExpectedAction( 'constantcontactsubmit' );

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -351,7 +351,7 @@ class ConstantContact_Process_Form {
 		} else {
 
 			// No need to check for opt in status because we would have returned early by now if false.
-			$maybe_bypass = ctct_get_settings_option( '_ctct_bypass_cron', '' );
+			$maybe_bypass = constant_contact_get_option( '_ctct_bypass_cron', '' );
 
 			if ( constant_contact()->api->is_connected() && 'on' === $maybe_bypass ) {
 				constant_contact()->mail->submit_form_values( $return['values'] ); // Emails but doesn't schedule cron.

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -239,7 +239,7 @@ class ConstantContact_Process_Form {
 				 * @param  float  $value Required threshold value.
 				 * @param  string $value Form ID.
 				 */
-				$threshold = (float) apply_filters( 'constant_contact_recaptcha_threshold', 0.5, $data['ctct-id'] );
+				$threshold = (float) apply_filters( 'constant_contact_recaptcha_threshold', $threshold, $data['ctct-id'] );
 
 				$ctctrecaptcha->recaptcha->setScoreThreshold( $threshold );
 				$ctctrecaptcha->recaptcha->setExpectedAction( 'constantcontactsubmit' );

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -663,7 +663,18 @@ class ConstantContact_Process_Form {
 				 * @param  string     $value Success message.
 				 * @param  string/int $form_id ID of the Constant Contact form being submitted to.
 				 */
-				$message = apply_filters( 'ctct_process_form_success', __( 'Your information has been submitted.', 'constant-contact-forms' ), $form_id ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Hookname is prefixed.
+				$message = apply_filters_deprecated( 'ctct_process_form_success', [ __( 'Your information has been submitted.', 'constant-contact-forms' ), $form_id ], 'NEXT', 'constant_contact_process_form_success' );
+
+				/**
+				 * Filters the message for the successful processed form.
+				 *
+				 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+				 * @since  NEXT
+				 *
+				 * @param  string     $value   Success message.
+				 * @param  string|int $form_id Constant Contact form ID.
+				 */
+				$message = apply_filters( 'constant_contact_process_form_success', $message, $form_id );
 				break;
 
 			case 'error':

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -97,8 +97,8 @@ class ConstantContact_reCAPTCHA {
 	 * @return bool
 	 */
 	public static function has_recaptcha_keys() {
-		$site_key   = ctct_get_settings_option( '_ctct_recaptcha_site_key', '' );
-		$secret_key = ctct_get_settings_option( '_ctct_recaptcha_secret_key', '' );
+		$site_key   = constant_contact_get_option( '_ctct_recaptcha_site_key', '' );
+		$secret_key = constant_contact_get_option( '_ctct_recaptcha_secret_key', '' );
 
 		return $site_key && $secret_key;
 	}
@@ -112,8 +112,8 @@ class ConstantContact_reCAPTCHA {
 	 */
 	public function get_recaptcha_keys() {
 		$keys               = [];
-		$keys['site_key']   = ctct_get_settings_option( '_ctct_recaptcha_site_key', '' );
-		$keys['secret_key'] = ctct_get_settings_option( '_ctct_recaptcha_secret_key', '' );
+		$keys['site_key']   = constant_contact_get_option( '_ctct_recaptcha_site_key', '' );
+		$keys['secret_key'] = constant_contact_get_option( '_ctct_recaptcha_secret_key', '' );
 
 		return $keys;
 	}
@@ -151,6 +151,6 @@ class ConstantContact_reCAPTCHA {
 	 * @since 1.7.0
 	 */
 	public function set_recaptcha_version() {
-		$this->version = ctct_get_settings_option( '_ctct_recaptcha_version', '' );
+		$this->version = constant_contact_get_option( '_ctct_recaptcha_version', '' );
 	}
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -989,23 +989,6 @@ class ConstantContact_Settings {
 }
 
 /**
- * Wrapper function around cmb2_get_option.
- *
- * @deprecated NEXT Deprecated in favor of properly-prefixed function name.
- *
- * @since  1.0.0
- *
- * @param  string $key     Options array key.
- * @param  string $default Default value if no option exists.
- * @return mixed           Option value.
- */
-function ctct_get_settings_option( $key = '', $default = null ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Function is prefixed.
-	_deprecated_function( __FUNCTION__, 'NEXT', 'constant_contact_get_option' );
-
-	return constant_contact_get_option( $key, $default );
-}
-
-/**
  * Retrieve option value.
  *
  * Wrapper for `cmb2_get_option` to provide fallback when that function is not available.

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -86,7 +86,7 @@ class ConstantContact_Settings {
 		add_filter( 'preprocess_comment', [ $this, 'process_optin_comment_form' ] );
 		add_filter( 'authenticate', [ $this, 'process_optin_login_form' ], 10, 3 );
 		add_action( 'cmb2_save_field__ctct_logging', [ $this, 'maybe_init_logs' ], 10, 3 );
-		add_filter( 'ctct_custom_spam_message', [ $this, 'get_spam_error_message' ], 10, 2 );
+		add_filter( 'constant_contact_custom_spam_message', [ $this, 'get_spam_error_message' ], 10, 2 );
 	}
 
 	/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -991,25 +991,45 @@ class ConstantContact_Settings {
 /**
  * Wrapper function around cmb2_get_option.
  *
- * @since 1.0.0
+ * @deprecated NEXT Deprecated in favor of properly-prefixed function name.
  *
- * @param string $key     Options array key.
- * @param string $default Default value if no option exists.
- * @return mixed Option value.
+ * @since  1.0.0
+ *
+ * @param  string $key     Options array key.
+ * @param  string $default Default value if no option exists.
+ * @return mixed           Option value.
  */
 function ctct_get_settings_option( $key = '', $default = null ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Function is prefixed.
+	_deprecated_function( __FUNCTION__, 'NEXT', 'constant_contact_get_option' );
+
+	return constant_contact_get_option( $key, $default );
+}
+
+/**
+ * Retrieve option value.
+ *
+ * Wrapper for `cmb2_get_option` to provide fallback when that function is not available.
+ *
+ * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+ * @since  NEXT
+ *
+ * @param  string $key     Option key.
+ * @param  mixed  $default Default option value.
+ * @return mixed           Option value.
+ */
+function constant_contact_get_option( $key = '', $default = null ) {
 	if ( function_exists( 'cmb2_get_option' ) ) {
 		return cmb2_get_option( constant_contact()->settings->key, $key, $default );
 	}
 
-	$opts = get_option( constant_contact()->settings->key, $key, $default );
-	$val  = $default;
+	$options = get_option( constant_contact()->settings->key, $key, $default );
+	$value   = $default;
 
 	if ( 'all' === $key ) {
-		$val = $opts;
-	} elseif ( is_array( $opts ) && array_key_exists( $key, $opts ) && false !== $opts[ $key ] ) {
-		$val = $opts[ $key ];
+		$value = $options;
+	} elseif ( is_array( $options ) && array_key_exists( $key, $options ) && false !== $options[ $key ] ) {
+		$value = $options[ $key ];
 	}
 
-	return $val;
+	return $value;
 }

--- a/includes/class-uninstall.php
+++ b/includes/class-uninstall.php
@@ -124,11 +124,23 @@ class ConstantContact_Uninstall {
 		/**
 		 * Allows filtering which transients are deleted upon plugin deactivation.
 		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
+		 *
 		 * @since 1.6.0
 		 *
 		 * @param array $transients One-dimensional array of transient names to delete.
 		 */
-		return apply_filters( 'ctct_transient_names_to_uninstall', $this->transients ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Hookname is prefixed.
+		$transients = apply_filters_deprecated( 'ctct_transient_names_to_uninstall', [ $this->transients ], 'NEXT', 'constant_contact_transient_names_to_uninstall' );
+
+		/**
+		 * Filters which transients are deleted when plugin is uninstalled.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param  array $transients Transients to be deleted.
+		 */
+		return apply_filters( 'constant_contact_transient_names_to_uninstall', $transients );
 	}
 
 	/**

--- a/includes/class-uninstall.php
+++ b/includes/class-uninstall.php
@@ -87,11 +87,23 @@ class ConstantContact_Uninstall {
 		/**
 		 * Allows filtering which options are deleted upon plugin deactivation.
 		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
+		 *
 		 * @since 1.6.0
 		 *
 		 * @param array $options One-dimensional array of option names to delete.
 		 */
-		return apply_filters( 'ctct_option_names_to_uninstall', $this->options ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Hookname is prefixed.
+		$options = apply_filters_deprecated( 'ctct_option_names_to_uninstall', [ $this->options ], 'NEXT', 'constant_contact_option_names_to_uninstall' );
+
+		/**
+		 * Filters which options are deleted when plugin is uninstalled.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param  array $options Options to be deleted.
+		 */
+		return apply_filters( 'constant_contact_option_names_to_uninstall', $options );
 	}
 
 	/**

--- a/includes/class-uninstall.php
+++ b/includes/class-uninstall.php
@@ -158,11 +158,23 @@ class ConstantContact_Uninstall {
 		/**
 		 * Allows filtering which cron hooks are deleted upon plugin deactivation.
 		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
+		 *
 		 * @since 1.6.0
 		 *
 		 * @param array $cron_hooks One-dimensional array of cron hook names to delete.
 		 */
-		return apply_filters( 'ctct_cron_hook_names_to_uninstall', $this->cron_hooks ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Hookname is prefixed.
+		$cron_hooks = apply_filters_deprecated( 'ctct_cron_hook_names_to_uninstall', [ $this->cron_hooks ], 'NEXT', 'constant_contact_cron_hook_names_to_uninstall' );
+
+		/**
+		 * Filters which cron hooks are deleted when plugin is uninstalled.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param  array $cron_hooks Cron hooks to be deleted.
+		 */
+		return apply_filters( 'constant_contact_cron_hook_names_to_uninstall', $cron_hooks );
 	}
 
 	/**

--- a/includes/class-user-customizations.php
+++ b/includes/class-user-customizations.php
@@ -43,7 +43,7 @@ class ConstantContact_User_Customizations {
 	 * @since 1.3.0
 	 */
 	public function hooks() {
-		add_filter( 'ctct_process_form_success', [ $this, 'process_form_success' ], 10, 2 );
+		add_filter( 'constant_contact_process_form_success', [ $this, 'process_form_success' ], 10, 2 );
 		add_filter( 'constant_contact_front_form_action', [ $this, 'custom_redirect' ], 10, 2 );
 		add_filter( 'constant_contact_destination_email', [ $this, 'custom_email' ], 10, 2 );
 	}

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -26,3 +26,20 @@ function ctct_get_settings_option( $key = '', $default = null ) {
 
 	return constant_contact_get_option( $key, $default );
 }
+
+/**
+ * Process potential custom Constant Contact Forms action urls.
+ *
+ * @deprecated NEXT Deprecated in favor of properly-prefixed function name.
+ *
+ * @since  1.2.3
+ *
+ * @throws Exception Throw Exception if error occurs during form processing.
+ *
+ * @return bool|array
+ */
+function ctct_custom_form_action_processing() {
+	_deprecated_function( __FUNCTION__, 'NEXT', 'constant_contact_process_form_custom' );
+
+	return constant_contact_process_form_custom();
+}

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -43,3 +43,18 @@ function ctct_custom_form_action_processing() {
 
 	return constant_contact_process_form_custom();
 }
+
+/**
+ * Determine if we have any Constant Contact Forms published.
+ *
+ * @deprecated NEXT Deprecated in favor of properly-prefixed function name.
+ *
+ * @since 1.2.5
+ *
+ * @return bool
+ */
+function ctct_has_forms() {
+	_deprecated_function( __FUNCTION__, 'NEXT', 'constant_contact_has_forms' );
+
+	return constant_contact_has_forms();
+}

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -7,6 +7,7 @@
  * @since   NEXT
  *
  * phpcs:disable WebDevStudios.All.RequireAuthor -- Don't require author tag in docblocks.
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Incorrectly prefixed functions have been deprecated.
  */
 
 /**
@@ -20,7 +21,7 @@
  * @param  string $default Default value if no option exists.
  * @return mixed           Option value.
  */
-function ctct_get_settings_option( $key = '', $default = null ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Function is prefixed.
+function ctct_get_settings_option( $key = '', $default = null ) {
 	_deprecated_function( __FUNCTION__, 'NEXT', 'constant_contact_get_option' );
 
 	return constant_contact_get_option( $key, $default );

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Deprecated functions.
+ *
+ * @package Constantcontact
+ * @author  Constant Contact
+ * @since   NEXT
+ *
+ * phpcs:disable WebDevStudios.All.RequireAuthor -- Don't require author tag in docblocks.
+ */
+
+/**
+ * Wrapper function around cmb2_get_option.
+ *
+ * @deprecated NEXT Deprecated in favor of properly-prefixed function name.
+ *
+ * @since  1.0.0
+ *
+ * @param  string $key     Options array key.
+ * @param  string $default Default value if no option exists.
+ * @return mixed           Option value.
+ */
+function ctct_get_settings_option( $key = '', $default = null ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Function is prefixed.
+	_deprecated_function( __FUNCTION__, 'NEXT', 'constant_contact_get_option' );
+
+	return constant_contact_get_option( $key, $default );
+}

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -293,19 +293,21 @@ function constant_contact_process_form_custom() {
 add_action( 'wp_head', 'constant_contact_process_form_custom' );
 
 /**
- * Determine if we have any Constant Contact Forms published.
+ * Check if any published Constant Contact forms exist.
  *
- * @since 1.2.5
+ * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+ * @since  NEXT
  *
- * @return bool
+ * @return bool Whether published forms exist.
  */
-function ctct_has_forms() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Function is prefixed.
+function constant_contact_has_forms() {
 	$args  = [
 		'post_type'      => 'ctct_forms',
 		'post_status'    => 'publish',
 		'posts_per_page' => 1,
 	];
 	$forms = new WP_Query( $args );
+
 	return $forms->have_posts();
 }
 

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -385,7 +385,7 @@ function constant_contact_clean_url( $url = '' ) {
  * @return bool
  */
 function constant_contact_debugging_enabled() {
-	$debugging_enabled = ctct_get_settings_option( '_ctct_logging', '' );
+	$debugging_enabled = constant_contact_get_option( '_ctct_logging', '' );
 
 	if ( apply_filters( 'constant_contact_force_logging', false ) ) {
 		$debugging_enabled = 'on';
@@ -568,7 +568,7 @@ function constant_contact_emails_disabled( $form_id = 0 ) {
 		$disabled = true;
 	}
 
-	$global_form_disabled = ctct_get_settings_option( '_ctct_disable_email_notifications', '' );
+	$global_form_disabled = constant_contact_get_option( '_ctct_disable_email_notifications', '' );
 	if ( 'on' === $global_form_disabled ) {
 		$disabled = true;
 	}
@@ -627,7 +627,7 @@ function constant_contact_get_css_customization( $form_id, $customization_key = 
 		}
 	}
 
-	$global_setting = ctct_get_settings_option( $customization_key );
+	$global_setting = constant_contact_get_option( $customization_key );
 
 	return ! empty( $global_setting ) ? $global_setting : '';
 }

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -270,16 +270,14 @@ function constant_contact_review_ajax_handler() {
 add_action( 'wp_ajax_constant_contact_review_ajax_handler', 'constant_contact_review_ajax_handler' );
 
 /**
- * Process potential custom Constant Contact Forms action urls.
+ * Perform custom form processing.
  *
- * @since 1.2.3
+ * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+ * @since  NEXT
  *
- * @throws Exception Throw Exception if error occurs during form processing.
- *
- * @return bool|array
+ * @return mixed Results of form processing, false if no processing performed.
  */
-function ctct_custom_form_action_processing() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Function is prefixed.
-
+function constant_contact_process_form_custom() {
 	$ctct_id = filter_input( INPUT_POST, 'ctct-id', FILTER_VALIDATE_INT );
 
 	if ( false === $ctct_id ) {
@@ -292,7 +290,7 @@ function ctct_custom_form_action_processing() { // phpcs:ignore WordPress.Naming
 
 	return constant_contact()->process_form->process_form();
 }
-add_action( 'wp_head', 'ctct_custom_form_action_processing' );
+add_action( 'wp_head', 'constant_contact_process_form_custom' );
 
 /**
  * Determine if we have any Constant Contact Forms published.


### PR DESCRIPTION
Ticket: [CC-178](https://webdevstudios.atlassian.net/browse/CC-178)

## Description ##

Deprecates functions and hooks with incorrect plugin prefix (`ctct_`), replacing with `constant_contact_` variations.
- Deprecates filters and actions with old prefix via `apply_filters_deprecated()` and `do_action_deprecated()`, respectively, and creates new, properly-prefixed filters and actions.
- Deprecates functions with old prefix:
    - Moves the original functions to a new `deprecated.php` file.
    - Calls `_deprecated_function()` within old functions to indicate improper usage.
    - Creates new functions with proper prefix in original functions' locations.
    - Calls new functions from old functions to preserve original functionality.
    - Updates calls to old functions to properly reference new functions.

## Steps ##

1. Confirm CC admin still functions as expected (no `debug.log` errors while accessing/saving CC settings).
2. Confirm CC frontend still functions as expected (no `debug.log` or other errors while viewing/submitting CC forms).

NOTE: I'm basing this PR on `sprint/20.07` as these changes are built upon previous "code update" branches that are currently merged to `sprint/20.07`, which has not yet been merged to `master`.