### PR TITLE
CC-183: Fix sprintf placeholders

### DIFF
--- a/includes/class-mail.php
+++ b/includes/class-mail.php
@@ -450,7 +450,7 @@ class ConstantContact_Mail {
 
 		return sprintf(
 			/* Translators: placeholders simply meant for `<strong>` html tags */
-			'<p>' . esc_html__( '%1\$sNote:%2\$s You have disabled admin email notifications under the plugin settings, but are receiving this email because of the following reason.', 'constant-contact-forms' ) . '</p>',
+			'<p>' . esc_html__( '%1$sNote:%2$s You have disabled admin email notifications under the plugin settings, but are receiving this email because of the following reason.', 'constant-contact-forms' ) . '</p>',
 			'<strong>*',
 			'</strong>'
 		);


### PR DESCRIPTION
Ticket: [CC-183](https://webdevstudios.atlassian.net/browse/CC-183)

### Description ###

Removes `\` within placeholder in `sprintf`, which was causing part of the placeholder to display to the end user.

### Screenshot ###

![Screenshot_2020-08-12 WP Mail Log ‹ Constant Contact Woo — WordPress](https://user-images.githubusercontent.com/36422618/90063137-244e1400-dca6-11ea-9ef8-42de64ae7238.png)

### Steps to test ###

The quickest way to force this to display in an admin email is the following:
1. Ensure the CC Forms setting "Disable E-mail Notifications" is _unchecked_.
2. At the top of the function body for `maybe_append_forced_email_notice_note()` (`includes/class-mail.php`), set `$was_forced = true` to force this message for all emails.
3. Process a form submission, and the corresponding admin email should include the "forced email" note as shown above.
