### PR TITLE
Chore/merge sprint 20 07 into sprint 20 08

### DIFF
--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -366,6 +366,8 @@ class Constant_Contact {
 	 * Sets up our plugin.
 	 *
 	 * @since 1.0.0
+	 *
+	 * @return void
 	 */
 	protected function __construct() {
 
@@ -373,9 +375,9 @@ class Constant_Contact {
 		$this->plugin_name = esc_html__( 'Constant Contact', 'constant-contact-forms' );
 
 		// Set up some helper properties.
-		$this->basename        = plugin_basename( __FILE__ );
-		$this->url             = plugin_dir_url( __FILE__ );
-		$this->path            = plugin_dir_path( __FILE__ );
+		$this->basename = plugin_basename( __FILE__ );
+		$this->url      = plugin_dir_url( __FILE__ );
+		$this->path     = plugin_dir_path( __FILE__ );
 
 		if ( ! $this->meets_php_requirements() ) {
 			add_action( 'admin_notices', array( $this, 'minimum_version' ) );
@@ -394,6 +396,9 @@ class Constant_Contact {
 
 		// Include compatibility fixes to address conflicts with other plug-ins.
 		self::include_file( 'compatibility', false );
+
+		// Include deprecated functions.
+		self::include_file( 'deprecated', false );
 	}
 
 	/**
@@ -449,6 +454,8 @@ class Constant_Contact {
 	 * Add hooks and filters.
 	 *
 	 * @since 1.0.0
+	 *
+	 * @return void
 	 */
 	public function hooks() {
 		if ( ! $this->meets_php_requirements() ) {
@@ -461,11 +468,6 @@ class Constant_Contact {
 		add_filter( 'body_class', array( $this, 'body_classes' ) );
 
 		$this->load_libs();
-
-		// Our vendor files will do a check for ISSSL, so we want to set it to be that. See Guzzle for more info and usage of this.
-		if ( is_ssl() || ! defined( 'ISSSL' ) ) {
-			define( 'ISSSL', true );
-		}
 
 		add_filter( 'widget_text', 'do_shortcode' );
 		add_action( 'admin_enqueue_scripts', [ $this, 'register_admin_assets' ], 1 );

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -451,7 +451,7 @@ class ConstantContact_Admin {
 
 		global $pagenow;
 
-		$debug = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG === true );
+		$debug  = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG === true );
 		$suffix = ( true === $debug ) ? '' : '.min';
 
 		wp_register_script(

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -128,8 +128,8 @@ class ConstantContact_API {
 				}
 			} catch ( CtctException $ex ) {
 				add_filter( 'constant_contact_force_logging', '__return_true' );
-				$extra = constant_contact_location_and_line( __METHOD__, __LINE__ );
-				$errors = $ex->getErrors();
+				$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
+				$errors       = $ex->getErrors();
 				$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 				$this->log_errors( $our_errors );
 				constant_contact_set_has_exceptions();
@@ -173,8 +173,8 @@ class ConstantContact_API {
 
 			} catch ( CtctException $ex ) {
 				add_filter( 'constant_contact_force_logging', '__return_true' );
-				$extra = constant_contact_location_and_line( __METHOD__, __LINE__ );
-				$errors = $ex->getErrors();
+				$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
+				$errors       = $ex->getErrors();
 				$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 				$this->log_errors( $our_errors );
 				constant_contact_set_has_exceptions();
@@ -226,14 +226,14 @@ class ConstantContact_API {
 				}
 			} catch ( CtctException $ex ) {
 				add_filter( 'constant_contact_force_logging', '__return_true' );
-				$extra = constant_contact_location_and_line( __METHOD__, __LINE__ );
-				$errors = $ex->getErrors();
+				$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
+				$errors       = $ex->getErrors();
 				$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 				$this->log_errors( $our_errors );
 				constant_contact_set_has_exceptions();
 			} catch ( Exception $ex ) {
-				$error = new stdClass();
-				$error->error_key = get_class( $ex );
+				$error                = new stdClass();
+				$error->error_key     = get_class( $ex );
 				$error->error_message = $ex->getMessage();
 
 				add_filter( 'constant_contact_force_logging', '__return_true' );
@@ -277,8 +277,8 @@ class ConstantContact_API {
 				return $list;
 			} catch ( CtctException $ex ) {
 				add_filter( 'constant_contact_force_logging', '__return_true' );
-				$extra = constant_contact_location_and_line( __METHOD__, __LINE__ );
-				$errors = $ex->getErrors();
+				$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
+				$errors       = $ex->getErrors();
 				$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 				$this->log_errors( $our_errors );
 				constant_contact_set_has_exceptions();
@@ -320,8 +320,8 @@ class ConstantContact_API {
 			$list = $this->cc()->listService->getList( $this->get_api_token(), esc_attr( $new_list['id'] ) );
 		} catch ( CtctException $ex ) {
 			add_filter( 'constant_contact_force_logging', '__return_true' );
-			$extra = constant_contact_location_and_line( __METHOD__, __LINE__ );
-			$errors = $ex->getErrors();
+			$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
+			$errors       = $ex->getErrors();
 			$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 			$this->log_errors( $our_errors );
 			constant_contact_set_has_exceptions();
@@ -361,8 +361,8 @@ class ConstantContact_API {
 
 		} catch ( CtctException $ex ) {
 			add_filter( 'constant_contact_force_logging', '__return_true' );
-			$extra = constant_contact_location_and_line( __METHOD__, __LINE__ );
-			$errors = $ex->getErrors();
+			$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
+			$errors       = $ex->getErrors();
 			$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 			$this->log_errors( $our_errors );
 			constant_contact_set_has_exceptions();
@@ -414,8 +414,8 @@ class ConstantContact_API {
 
 		} catch ( CtctException $ex ) {
 			add_filter( 'constant_contact_force_logging', '__return_true' );
-			$extra = constant_contact_location_and_line( __METHOD__, __LINE__ );
-			$errors = $ex->getErrors();
+			$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
+			$errors       = $ex->getErrors();
 			$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 			$this->log_errors( $our_errors );
 			constant_contact_set_has_exceptions();
@@ -455,8 +455,8 @@ class ConstantContact_API {
 			$list = $this->cc()->listService->deleteList( $this->get_api_token(), $updated_list['id'] );
 		} catch ( CtctException $ex ) {
 			add_filter( 'constant_contact_force_logging', '__return_true' );
-			$extra = constant_contact_location_and_line( __METHOD__, __LINE__ );
-			$errors = $ex->getErrors();
+			$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
+			$errors       = $ex->getErrors();
 			$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 			$this->log_errors( $our_errors );
 			constant_contact_set_has_exceptions();
@@ -482,7 +482,7 @@ class ConstantContact_API {
 	 * @since 1.0.0
 	 * @since 1.3.0 Added $form_id parameter.
 	 *
-	 * @throws Exception
+	 * @throws Exception Throws Exception if encountered while attempting to save contact.
 	 *
 	 * @param array $new_contact New contact data.
 	 * @param int   $form_id     ID of the form being processed.
@@ -524,8 +524,8 @@ class ConstantContact_API {
 			}
 		} catch ( CtctException $ex ) {
 			add_filter( 'constant_contact_force_logging', '__return_true' );
-			$extra = constant_contact_location_and_line( __METHOD__, __LINE__ );
-			$errors = $ex->getErrors();
+			$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
+			$errors       = $ex->getErrors();
 			$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 			$this->log_errors( $our_errors );
 			if ( 400 !== $ex->getCode() || false !== strpos( 'Bad Request', $ex->getMessage() ) ) {
@@ -566,7 +566,7 @@ class ConstantContact_API {
 			if ( is_array( $contact_value ) ) {
 				$clean[ $contact_key ] = $this->clear_email( $contact_value );
 			} elseif ( is_email( $contact_value ) ) {
-				$email_parts = explode( '@', $contact_value );
+				$email_parts           = explode( '@', $contact_value );
 				$clean[ $contact_key ] = implode( '@', [ '***', $email_parts[1] ] );
 			} else {
 				$clean[ $contact_key ] = $contact_value;
@@ -598,8 +598,8 @@ class ConstantContact_API {
 			$contact = $this->set_contact_properties( $contact, $user_data, $form_id );
 		} catch ( CtctException $ex ) {
 			add_filter( 'constant_contact_force_logging', '__return_true' );
-			$extra = constant_contact_location_and_line( __METHOD__, __LINE__ );
-			$errors = $ex->getErrors();
+			$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
+			$errors       = $ex->getErrors();
 			$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 			$this->log_errors( $our_errors );
 			constant_contact_set_has_exceptions();
@@ -657,8 +657,8 @@ class ConstantContact_API {
 				$contact = $this->set_contact_properties( $contact, $user_data, $form_id, true );
 			} catch ( CtctException $ex ) {
 				add_filter( 'constant_contact_force_logging', '__return_true' );
-				$extra = constant_contact_location_and_line( __METHOD__, __LINE__ );
-				$errors = $ex->getErrors();
+				$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
+				$errors       = $ex->getErrors();
 				$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 				$this->log_errors( $our_errors );
 				constant_contact_set_has_exceptions();
@@ -847,7 +847,7 @@ class ConstantContact_API {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @throws Exception
+	 * @throws Exception Throws Exception if encountered while attempting to log errors.
 	 *
 	 * @param array $errors Errors from API.
 	 */
@@ -868,7 +868,7 @@ class ConstantContact_API {
 	 * @since 1.0.0
 	 * @since 1.8.6 Deprected
 	 *
-	 * @throws Exception
+	 * @throws Exception Throws Exception if encountered while attempting to process error message.
 	 *
 	 * @param array $error API error repsonse.
 	 * @return mixed
@@ -985,8 +985,8 @@ class ConstantContact_API {
 		}
 
 		$disclosure = [
-			'name'    => empty( $account_info->organization_name ) ? ctct_get_settings_option( '_ctct_disclose_name', '' ) : $account_info->organization_name,
-			'address' => ctct_get_settings_option( '_ctct_disclose_address', '' ),
+			'name'    => empty( $account_info->organization_name ) ? constant_contact_get_option( '_ctct_disclose_name', '' ) : $account_info->organization_name,
+			'address' => constant_contact_get_option( '_ctct_disclose_address', '' ),
 		];
 
 		if ( empty( $disclosure['name'] ) ) {

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -823,8 +823,8 @@ class ConstantContact_API {
 					try {
 						$contact->$key = $value;
 					} catch ( Exception $e ) {
-						$errors = [];
-						$extra = constant_contact_location_and_line( __METHOD__, __LINE__ );
+						$errors   = [];
+						$extra    = constant_contact_location_and_line( __METHOD__, __LINE__ );
 						$errors[] = $extra . $e->getErrors();
 						$this->log_errors( $errors );
 						constant_contact_set_has_exceptions();

--- a/includes/class-builder-fields.php
+++ b/includes/class-builder-fields.php
@@ -149,7 +149,7 @@ class ConstantContact_Builder_Fields {
 			],
 			'website'          => [
 				'option'      => esc_html__( 'Website', 'constant-contact-forms' ),
-				'placeholder' => esc_html__( 'http://www.example.com', 'constant-contact-form' ),
+				'placeholder' => esc_html__( 'http://www.example.com', 'constant-contact-forms' ),
 			],
 			'custom'           => [
 				'option'      => esc_html__( 'Custom Text Field', 'constant-contact-forms' ),
@@ -449,7 +449,7 @@ class ConstantContact_Builder_Fields {
 			'id'          => 'form-padding-title',
 			'description' => esc_html__(
 				'Enter padding values in number of pixels. Padding will be applied to four sides of the form.',
-				'constant-contact-form' ),
+				'constant-contact-forms' ),
 		] );
 
 		$custom_css_metabox->add_field( [

--- a/includes/class-check.php
+++ b/includes/class-check.php
@@ -177,6 +177,8 @@ class ConstantContact_Check {
 		$sslverify     = version_compare( $wp_version, 4.0, '<' );
 		$doing_wp_cron = sprintf( '%.22F', microtime( true ) );
 
+		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Filters defined in WP Core.
+		/* This filter is documented in wp-includes/cron.php */
 		$cron_request = apply_filters( 'cron_request', [
 			'url'  => site_url( 'wp-cron.php?doing_wp_cron=' . $doing_wp_cron ),
 			'key'  => $doing_wp_cron,
@@ -186,6 +188,7 @@ class ConstantContact_Check {
 				'sslverify' => apply_filters( 'https_local_ssl_verify', $sslverify ),
 			],
 		] );
+		// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 		$cron_request['args']['blocking'] = true;
 

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -320,7 +320,7 @@ class ConstantContact_Connect {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @throws Exception
+	 * @throws Exception Throw Exception if encountered during disconnection.
 	 *
 	 * @return boolean
 	 */
@@ -359,7 +359,7 @@ class ConstantContact_Connect {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @throws Exception
+	 * @throws Exception Throws Exception if encountered while attempting to retrieve encrypted value.
 	 *
 	 * @param string  $check_key key to save to.
 	 * @param boolean $fallback_to_ctct_opt Fall back maybe.
@@ -444,7 +444,7 @@ class ConstantContact_Connect {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @throws Exception
+	 * @throws Exception Throws Exception if encountered while attempting to save API token.
 	 *
 	 * @return string Token.
 	 */
@@ -508,8 +508,8 @@ class ConstantContact_Connect {
 			return 'ctct_key';
 		}
 
-		$key = Key::createNewRandomKey();
-		$key = $key->saveToAsciiSafeString();
+		$key     = Key::createNewRandomKey();
+		$key     = $key->saveToAsciiSafeString();
 		$updated = update_option( 'ctct_key', $key );
 
 		if ( ! $updated || $first_try ) {

--- a/includes/class-cpts.php
+++ b/includes/class-cpts.php
@@ -179,8 +179,9 @@ class ConstantContact_CPTS {
 	 * @return array appended update messages with custom post types.
 	 */
 	public function post_updated_messages( $messages ) {
-
 		global $post;
+
+		$revision = filter_input( INPUT_GET, 'revision', FILTER_SANITIZE_NUMBER_INT );
 
 		$messages['ctct_lists'] = [
 			0  => '', // Unused. Messages start at index 1.
@@ -188,10 +189,14 @@ class ConstantContact_CPTS {
 			2  => __( 'Custom field updated.', 'constant-contact-forms' ),
 			3  => __( 'Custom field deleted.', 'constant-contact-forms' ),
 			4  => __( 'List updated.', 'constant-contact-forms' ),
-			5  => isset( $_GET['revision'] ) ? sprintf( __( 'List restored to revision from %s', 'constant-contact-forms' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+			5  => ! empty( $revision ) ?
+				/* translators: formatted revision timestamp. */
+				sprintf( __( 'List restored to revision from %s', 'constant-contact-forms' ), wp_post_revision_title( $revision, false ) ) :
+				false,
 			6  => __( 'List published.', 'constant-contact-forms' ),
 			7  => __( 'List saved.', 'constant-contact-forms' ),
 			8  => __( 'List submitted.', 'constant-contact-forms' ),
+			/* translators: formatted post date timestamp. */
 			9  => __( 'List scheduled for: <strong>%1$s</strong>.', 'constant-contact-forms' ),
 			date_i18n( 'M j, Y @ G:i', strtotime( $post->post_date ) ),
 			10 => __( 'List draft updated.', 'constant-contact-forms' ),
@@ -203,10 +208,18 @@ class ConstantContact_CPTS {
 			2  => __( 'Custom field updated.', 'constant-contact-forms' ),
 			3  => __( 'Custom field deleted.', 'constant-contact-forms' ),
 			4  => __( 'Form updated.', 'constant-contact-forms' ),
-			5  => isset( $_GET['revision'] ) ? sprintf( __( 'Form restored to revision from %s', 'constant-contact-forms' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
-			6  => sprintf( __( "Success! Here's the shortcode: %s. Just paste it into a post or page editor to publish", 'constant-contact-forms' ), '<strong>' . constant_contact_display_shortcode( $post->ID ) . '</strong>' ),
+			5  => ! empty( $revision ) ?
+				/* translators: formatted revision timestamp. */
+				sprintf( __( 'Form restored to revision from %s', 'constant-contact-forms' ), wp_post_revision_title( $revision, false ) ) :
+				false,
+			6  => sprintf(
+					/* translators: form shortcode. */
+					__( "Success! Here's the shortcode: %s. Just paste it into a post or page editor to publish", 'constant-contact-forms' ),
+					'<strong>' . constant_contact_display_shortcode( $post->ID ) . '</strong>'
+				),
 			7  => __( 'Form saved.', 'constant-contact-forms' ),
 			8  => __( 'Form submitted.', 'constant-contact-forms' ),
+			/* translators: formatted post date timestamp. */
 			9  => __( 'Form scheduled for: <strong>%1$s</strong>.', 'constant-contact-forms' ),
 			date_i18n( 'M j, Y @ G:i', strtotime( $post->post_date ) ),
 			10 => __( 'Form draft updated.', 'constant-contact-forms' ),

--- a/includes/class-display-shortcode.php
+++ b/includes/class-display-shortcode.php
@@ -127,7 +127,7 @@ class ConstantContact_Display_Shortcode {
 	 * @param bool $show_title If true, show the title.
 	 */
 	public function display_form( $form_id, $show_title = false ) {
-		echo $this->get_form( absint( $form_id ), $show_title ); // WPCS: XSS Ok.
+		echo $this->get_form( absint( $form_id ), $show_title ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- XSS OK.
 	}
 
 	/**

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -110,12 +110,12 @@ class ConstantContact_Display {
 
 		$global_form_css = [];
 
-		$global_form_classes = ctct_get_settings_option( '_ctct_form_custom_classes' );
+		$global_form_classes = constant_contact_get_option( '_ctct_form_custom_classes' );
 		if ( $global_form_classes ) {
 			$global_form_css['global_form_classes'] = $global_form_classes;
 		}
 
-		$global_label_placement = ctct_get_settings_option( 'ctct_form_label_placement' );
+		$global_label_placement = constant_contact_get_option( 'ctct_form_label_placement' );
 		if ( $global_label_placement ) {
 			$global_form_css['global_label_placement'] = $global_label_placement;
 		}
@@ -328,14 +328,28 @@ class ConstantContact_Display {
 		}
 
 		ob_start();
+
 		/**
 		 * Fires before the start of the form tag.
+		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
 		 *
 		 * @since 1.4.0
 		 *
 		 * @param int $form_id Current form ID.
 		 */
-		do_action( 'ctct_before_form', $form_id );
+		do_action_deprecated( 'ctct_before_form', [ $form_id ], 'NEXT', 'constant_contact_before_form' );
+
+		/**
+		 * Fires before the opening form tag.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param int $form_id Current form ID.
+		 */
+		do_action( 'constant_contact_before_form', $form_id );
+
 		$return .= ob_get_clean();
 
 		$return .= '<form class="' . esc_attr( $form_classes ) . '" id="' . $rf_id . '" ';
@@ -349,7 +363,7 @@ class ConstantContact_Display {
 		$return .= $this->build_form_fields( $form_data, $old_values, $req_errors, $instance );
 
 		if ( ! $disable_recaptcha && ConstantContact_reCAPTCHA::has_recaptcha_keys() ) {
-			$recaptcha_version = ctct_get_settings_option( '_ctct_recaptcha_version', '' );
+			$recaptcha_version = constant_contact_get_option( '_ctct_recaptcha_version', '' );
 			if ( 'v2' === $recaptcha_version ) {
 				$return .= $this->build_recaptcha( $form_id );
 			}
@@ -372,14 +386,28 @@ class ConstantContact_Display {
 		$return .= '</form>';
 
 		ob_start();
+
 		/**
 		 * Fires after the end of the form tag.
+		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
 		 *
 		 * @since 1.4.0
 		 *
 		 * @param int $form_id Current form ID.
 		 */
-		do_action( 'ctct_after_form', $form_id );
+		do_action_deprecated( 'ctct_after_form', [ $form_id ], 'NEXT', 'constant_contact_after_form' );
+
+		/**
+		 * Fires after the closing form tag.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param int $form_id Current form ID.
+		 */
+		do_action( 'constant_contact_after_form', $form_id );
+
 		$return .= ob_get_clean();
 
 		$return .= '<script type="text/javascript">';
@@ -739,6 +767,7 @@ class ConstantContact_Display {
 		foreach ( $submitted_vals as $post ) {
 
 			if ( isset( $post['key'] ) && $post['key'] ) {
+				$post_map = filter_input( INPUT_POST, esc_attr( $map ), FILTER_SANITIZE_STRING );
 
 				if ( 'address' === $field['name'] ) {
 
@@ -747,23 +776,15 @@ class ConstantContact_Display {
 						$addr_key = explode( '___', $post['key'] );
 
 						if ( isset( $addr_key[0] ) && $addr_key[0] ) {
-
-							$post_key = '';
-
-							// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification -- Okay accessing of $_POST value.
-							if ( isset( $_POST[ esc_attr( $post['key'] ) ] ) ) {
-								$post_key = sanitize_text_field( wp_unslash( $_POST[ esc_attr( $post['key'] ) ] ) );
-							}
-							// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
+							$post_key = filter_input( INPUT_POST, esc_attr( $post['key'] ), FILTER_SANITIZE_STRING );
+							$post_key = empty( $post_key ) ? '' : sanitize_text_field( wp_unslash( $post_key ) );
 
 							$return[ esc_attr( $addr_key[0] ) ] = $post_key;
 						}
 					}
-				// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification -- Okay accessing of $_POST value.
-				} elseif ( $post['key'] === $map && isset( $_POST[ esc_attr( $map ) ] ) ) {
-					return sanitize_text_field( wp_unslash( $_POST[ esc_attr( $map ) ] ) );
+				} elseif ( $post['key'] === $map && ! empty( $post_map ) ) {
+					return sanitize_text_field( wp_unslash( $post_map ) );
 				}
-				// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
 			}
 		}
 

--- a/includes/class-gutenberg.php
+++ b/includes/class-gutenberg.php
@@ -85,7 +85,7 @@ class ConstantContact_Gutenberg {
 		}
 
 		ob_start();
-		echo constant_contact_get_form( absint( $attributes['selectedForm'] ) ); // WPCS: XSS OK.
+		echo constant_contact_get_form( absint( $attributes['selectedForm'] ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- XSS OK.
 		return ob_get_clean();
 	}
 }

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -348,11 +348,23 @@ class ConstantContact_Lists {
 		/**
 		 * Hook when a ctct list is updated.
 		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
+		 *
 		 * @since 1.0.0
 		 *
 		 * @param array $lists_to_insert CTCT returned list data.
 		 */
-		do_action( 'ctct_sync_lists', $lists_to_insert );
+		do_action_deprecated( 'ctct_sync_lists', [ $lists_to_insert ], 'NEXT', 'constant_contact_sync_lists' );
+
+		/**
+		 * Fires after lists synced.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param  array $lists_to_insert Synced Constant Contact lists.
+		 */
+		do_action( 'constant_contact_sync_lists', $lists_to_insert );
 	}
 
 	/**
@@ -474,13 +486,27 @@ class ConstantContact_Lists {
 		/**
 		 * Hook when a ctct list is saved.
 		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
+		 *
 		 * @since 1.0.0
 		 *
 		 * @param integer $post_id CPT post id.
 		 * @param integer $list_id Ctct list id.
 		 * @param array   $list    Ctct returned list data.
 		 */
-		do_action( 'ctct_update_list', $ctct_list->ID, $list_id, $list );
+		do_action_deprecated( 'ctct_update_list', [ $ctct_list->ID, $list_id, $list ], 'NEXT', 'constant_contact_update_list' );
+
+		/**
+		 * Fires when a list is updated.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param  integer $post_id Form post ID.
+		 * @param  integer $list_id CTCT list ID.
+		 * @param  array   $list    CTCT list data.
+		 */
+		do_action( 'constant_contact_update_list', $ctct_list->ID, $list_id, $list );
 
 		return is_object( $list ) && isset( $list->id );
 	}
@@ -623,15 +649,11 @@ class ConstantContact_Lists {
 			]
 		);
 
-		/**
-		 * Hook when a ctct list is updated.
-		 *
-		 * @since 1.0.0
-		 * @param integer $post_id CPT post id.
-		 * @param integer $list_id Ctct list id.
-		 * @param array   $list    Ctct returned list data.
-		 */
-		do_action( 'ctct_update_list', $ctct_list->ID, $list_id, $list );
+		/* This deprecated filter is documented in includes/class-lists.php */
+		do_action_deprecated( 'ctct_update_list', [ $ctct_list->ID, $list_id, $list ], 'NEXT', 'constant_contact_update_list' );
+
+		/* This filter is documented in includes/class-lists.php */
+		do_action( 'constant_contact_update_list', $ctct_list->ID, $list_id, $list );
 
 		return is_object( $list ) && isset( $list->id );
 	}
@@ -667,12 +689,25 @@ class ConstantContact_Lists {
 		/**
 		 * Hook when a ctct list is deleted.
 		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
+		 *
 		 * @since 1.0.0
 		 *
 		 * @param integer $post_id Form list ID that was deleted.
 		 * @param integer $list_id Constant Contact list ID.
 		 */
-		do_action( 'ctct_delete_list', $post_id, $list_id );
+		do_action_deprecated( 'ctct_delete_list', [ $post_id, $list_id ], 'NEXT', 'constant_contact_delete_list' );
+
+		/**
+		 * Fires when a list is deleted.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param  integer $post_id Form post ID.
+		 * @param  integer $list_id CTCT list ID.
+		 */
+		do_action( 'constant_contact_delete_list', $post_id, $list_id );
 
 		return $list;
 	}

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -166,7 +166,7 @@ class ConstantContact_Logging {
 	 */
 	public function add_options_page() {
 
-		$debugging_enabled = ctct_get_settings_option( '_ctct_logging', '' );
+		$debugging_enabled = constant_contact_get_option( '_ctct_logging', '' );
 
 		if ( 'on' !== $debugging_enabled ) {
 			return;
@@ -185,6 +185,12 @@ class ConstantContact_Logging {
 		);
 	}
 
+	/**
+	 * Set file system.
+	 *
+	 * @author Michael Beckwith <michael@webdevstudios.com>
+	 * @since  1.4.5
+	 */
 	public function set_file_system() {
 		global $wp_filesystem;
 		WP_Filesystem();
@@ -226,8 +232,7 @@ class ConstantContact_Logging {
 				}
 
 				if ( is_file( $this->log_location_file ) && is_readable( $this->log_location_file ) ) {
-					// phpcs:ignore -- Not reading over network, it's on the filesystem.
-					$contents .= file_get_contents( $this->log_location_file );
+					$contents .= file_get_contents( $this->log_location_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Not reading over network, it's on the filesystem.
 				}
 
 				?>
@@ -441,6 +446,7 @@ class ConstantContact_Logging {
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
 	 * @since  1.8.2
 	 *
+	 * @param  string $dir Directory path.
 	 * @return void
 	 */
 	protected function delete_log_dir( $dir = '' ) {

--- a/includes/class-mail.php
+++ b/includes/class-mail.php
@@ -65,7 +65,7 @@ class ConstantContact_Mail {
 
 		if ( $add_to_opt_in && constant_contact()->api->is_connected() ) {
 
-			$maybe_bypass = ctct_get_settings_option( '_ctct_bypass_cron', '' );
+			$maybe_bypass = constant_contact_get_option( '_ctct_bypass_cron', '' );
 
 			if ( 'on' !== $maybe_bypass ) {
 				/**
@@ -239,7 +239,7 @@ class ConstantContact_Mail {
 	 * @since 1.0.0
 	 * @since 1.3.6 Added $was_forced.
 	 *
-	 * @throws Exception
+	 * @throws Exception Throws Exception if encountered while attempting to send email.
 	 *
 	 * @param string $destination_email  Intended mail address.
 	 * @param string $content            Data from clean values.
@@ -250,7 +250,7 @@ class ConstantContact_Mail {
 	public function mail( $destination_email, $content, $submission_details, $was_forced = false ) {
 
 		static $last_sent = false;
-		$screen = '';
+		$screen           = '';
 
 		if ( function_exists( 'get_current_screen' ) ) {
 			$screen = get_current_screen();
@@ -269,7 +269,7 @@ class ConstantContact_Mail {
 		} else {
 			if ( false !== strpos( $destination_email, ',' ) ) {
 				// Use trim to handle cases of ", ".
-				$partials = array_map( 'trim', explode( ',', $destination_email ) );
+				$partials      = array_map( 'trim', explode( ',', $destination_email ) );
 				$partial_email = array_map( [ $this, 'get_email_part' ], $partials );
 				$partial_email = implode( ',', $partial_email );
 			} else {

--- a/includes/class-middleware.php
+++ b/includes/class-middleware.php
@@ -1,5 +1,7 @@
 <?php
 /**
+ * Constant Contact Middleware.
+ *
  * @package ConstantContact
  * @subpackage Middleware
  * @author Constant Contact
@@ -58,8 +60,8 @@ class ConstantContact_Middleware {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $proof Proof key
-	 * @return string Signup/connect url.
+	 * @param  string $proof Proof key.
+	 * @return string        Signup/connect url.
 	 */
 	public function do_signup_url( $proof = '' ) {
 		return $this->do_connect_url( $proof, [ 'new_signup' => true ] );
@@ -129,19 +131,24 @@ class ConstantContact_Middleware {
 	/**
 	 * Verify a returned request from the auth server, and save the returned token.
 	 *
-	 * @throws Exception
+	 * @since  1.0.0
+	 *
+	 * @throws Exception Throws Exception if encountered while attempting to verify request.
 	 *
 	 * @return boolean Is valid?
 	 */
 	public function verify_and_save_access_token_return() {
+		$proof = filter_input( INPUT_GET, 'proof', FILTER_SANITIZE_STRING );
+		$token = filter_input( INPUT_GET, 'token', FILTER_SANITIZE_STRING );
+		$key   = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_STRING );
 
 		// If we get this, we'll want to start our process of
 		// verifying the proof that the middleware server gives us
 		// so that we can ignore any malicious entries that are sent to us
-		// Sanitize our expected data
-		$proof = isset( $_GET['proof'] ) ? sanitize_text_field( wp_unslash( $_GET['proof'] ) ) : false;
-		$token = isset( $_GET['token'] ) ? sanitize_text_field( wp_unslash( $_GET['token'] ) ) : false;
-		$key   = isset( $_GET['key'] ) ? sanitize_text_field( wp_unslash( $_GET['key'] ) ) : false;
+		// Sanitize our expected data.
+		$proof = ! empty( $proof ) ? sanitize_text_field( $proof ) : false;
+		$token = ! empty( $token ) ? sanitize_text_field( $token ) : false;
+		$key   = ! empty( $key ) ? sanitize_text_field( $key ) : false;
 
 		// If we're missing any piece of data, we failed.
 		if ( ! $proof || ! $token || ! $key ) {
@@ -156,7 +163,7 @@ class ConstantContact_Middleware {
 
 		constant_contact_maybe_log_it( 'Authentication', 'Authorization verification succeeded.' );
 
-	 	constant_contact()->connect->update_token( sanitize_text_field( $token ) );
+		constant_contact()->connect->update_token( sanitize_text_field( $token ) );
 		constant_contact()->connect->e_set( '_ctct_api_key', sanitize_text_field( $key ) );
 		return true;
 	}

--- a/includes/class-notification-content.php
+++ b/includes/class-notification-content.php
@@ -53,9 +53,9 @@ class ConstantContact_Notification_Content {
 				<?php
 					printf(
 
-						// translators: Placeholder will hold "Constan Contact Forms" with <strong> tags.
+						// translators: Placeholder will hold "Constant Contact Forms" with <strong> tags.
 						esc_attr__( 'Get the most out of the %s plugin &mdash; use it with an active Constant Contact account.', 'constant-contact-forms' ),
-						'<strong>' . esc_attr__( 'Constant Contact Forms' ) . '</strong>'
+						'<strong>' . esc_attr__( 'Constant Contact Forms', 'constant-contact-forms' ) . '</strong>'
 					);
 				?>
 			</p>
@@ -228,7 +228,7 @@ class ConstantContact_Notification_Content {
 		);
 
 		$reference_keys = array_keys( $references );
-		$last_key = array_pop( $reference_keys );
+		$last_key       = array_pop( $reference_keys );
 
 		array_walk( $references, function( $value, $key, $last_key ) {
 			if ( 'post' === $value['type'] ) {
@@ -240,7 +240,7 @@ class ConstantContact_Notification_Content {
 					esc_html( $value['id'] ),
 					esc_html( $key === $last_key ? '' : ', ' )
 				);
-			} else if ( 'widget' === $value['type'] ) {
+			} elseif ( 'widget' === $value['type'] ) {
 				printf(
 					/* Translators: 1: URL to widgets admin screen, 2: current widget name, 3: generic widget text, 4: current widget title, 5: preposition, 6: specific sidebar name, 7: separator between links. */
 					'<a href="%1$s">%2$s %3$s "%4$s" %5$s %6$s</a>%7$s',

--- a/includes/class-notifications.php
+++ b/includes/class-notifications.php
@@ -342,7 +342,7 @@ class ConstantContact_Notifications {
 
 		$is_true = ( ( 'true' === $option ) || ( '1' === $option ) );
 
-		return $is_true ?: false ;
+		return $is_true ?: false;
 	}
 
 	/**

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -54,20 +54,18 @@ class ConstantContact_Process_Form {
 	 * A wrapper to process our form via AJAX.
 	 *
 	 * @since 1.0.0
+	 *
+	 * @return void|array Return array of error data if error encountered, void otherwise.
 	 */
 	public function process_form_ajax_wrapper() {
 
 		// See if we're passed in data.
-		//
-		// We set to ignore this from PHPCS, as our nonce is handled elsewhere
-		// @codingStandardsIgnoreLine
-		if ( isset( $_POST['data'] ) ) { // Input var okay.
+		// We set to ignore this from PHPCS, as our nonce is handled elsewhere.
+		if ( isset( $_POST['data'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
-			// Form data comes over serialzied, so break it apart
-			//
-			// We set to ignore this from PHPCS, as our nonce is handled elsewhere
-			// @codingStandardsIgnoreLine
-			$data = explode( '&', $_POST['data'] );
+			// Form data comes over serialzied, so break it apart.
+			// We set to ignore this from PHPCS, as our nonce is handled elsewhere.
+			$data = explode( '&', $_POST['data'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 			// Finish converting that ajax data to something we can use.
 			$json_data = [];
@@ -125,10 +123,13 @@ class ConstantContact_Process_Form {
 			switch ( $status ) {
 
 				case 'success':
-					/** This filter is documented in includes/class-process-form.php */
-					$message = apply_filters( 'ctct_process_form_success',
-						__( 'Your information has been submitted.', 'constant-contact-forms' ),
-						(int) $json_data['ctct-id'] );
+					$form_id = (int) $json_data['ctct-id'];
+
+					/* This deprecated filter is documented in includes/class-process-form.php */
+					$message = apply_filters_deprecated( 'ctct_process_form_success', [ __( 'Your information has been submitted.', 'constant-contact-forms' ), $form_id ], 'NEXT', 'constant_contact_process_form_success' );
+
+					/* This filter is documented in includes/class-process-form.php */
+					$message = apply_filters( 'constant_contact_process_form_success', $message, $form_id );
 					break;
 
 				case 'error':
@@ -164,9 +165,10 @@ class ConstantContact_Process_Form {
 	/**
 	 * Process submitted form data.
 	 *
+	 * @author Brad Parbs <bradparbs@webdevstudios.com>
 	 * @since 1.0.0
 	 *
-	 * @throws Exception
+	 * @throws Exception Throws Exception if encountered while attempting to process form.
 	 *
 	 * @param array $data    Form data.
 	 * @param bool  $is_ajax Whether or not processing via AJAX.
@@ -224,19 +226,35 @@ class ConstantContact_Process_Form {
 			$keys = $ctctrecaptcha->get_recaptcha_keys();
 			$ctctrecaptcha->set_recaptcha_class( new ReCaptcha( $keys['secret_key'], $method ) );
 
-			$ctctrecaptcha->recaptcha->setExpectedHostname( parse_url( home_url(), PHP_URL_HOST ) );
+			$ctctrecaptcha->recaptcha->setExpectedHostname( wp_parse_url( home_url(), PHP_URL_HOST ) );
 			if ( 'v3' === $ctctrecaptcha->get_recaptcha_version() ) {
+
 				/**
 				 * Filters the default float value for the score threshold.
 				 *
 				 * This value should be between 0.0 and 1.0.
+				 *
+				 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
 				 *
 				 * @since 1.7.0
 				 *
 				 * @param float  $value Threshold to require for submission approval.
 				 * @param string $value The ID of the form that was submitted.
 				 */
-				$threshold = (float) apply_filters( 'ctct_recaptcha_threshold', 0.5, $data['ctct-id'] );
+				$threshold = apply_filters_deprecated( 'ctct_recaptcha_threshold', [ 0.5, $data['ctct-id'] ], 'NEXT', 'constant_contact_recaptcha_threshold' );
+
+				/**
+				 * Filters the default float value for the score threshold.
+				 *
+				 * This value should be between 0.0 and 1.0.
+				 *
+				 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+				 * @since  NEXT
+				 *
+				 * @param  float  $value Required threshold value.
+				 * @param  string $value Form ID.
+				 */
+				$threshold = (float) apply_filters( 'constant_contact_recaptcha_threshold', $threshold, $data['ctct-id'] );
 
 				$ctctrecaptcha->recaptcha->setScoreThreshold( $threshold );
 				$ctctrecaptcha->recaptcha->setExpectedAction( 'constantcontactsubmit' );
@@ -263,6 +281,7 @@ class ConstantContact_Process_Form {
 		/**
 		 * Filters whether or not we think an entry is spam.
 		 *
+		 * @author Michael Beckwith <michael@webdevstudios.com>
 		 * @since 1.3.2
 		 *
 		 * @param bool  $value Whether or not we thing an entry is spam. Default not spam.
@@ -357,7 +376,7 @@ class ConstantContact_Process_Form {
 		} else {
 
 			// No need to check for opt in status because we would have returned early by now if false.
-			$maybe_bypass = ctct_get_settings_option( '_ctct_bypass_cron', '' );
+			$maybe_bypass = constant_contact_get_option( '_ctct_bypass_cron', '' );
 
 			if ( constant_contact()->api->is_connected() && 'on' === $maybe_bypass ) {
 				constant_contact()->mail->submit_form_values( $return['values'] ); // Emails but doesn't schedule cron.
@@ -387,6 +406,7 @@ class ConstantContact_Process_Form {
 	/**
 	 * Pretty our values up.
 	 *
+	 * @author Brad Parbs <bradparbs@webdevstudios.com>
 	 * @since 1.0.0
 	 *
 	 * @param array $values Original values.
@@ -459,6 +479,7 @@ class ConstantContact_Process_Form {
 	/**
 	 * Gets our original field from a form id.
 	 *
+	 * @author Brad Parbs <bradparbs@webdevstudios.com>
 	 * @since 1.0.0
 	 *
 	 * @param int $form_id Form id.
@@ -492,38 +513,40 @@ class ConstantContact_Process_Form {
 				'required'    => isset( $field['_ctct_required_field'] ) && $field['_ctct_required_field'],
 			];
 
+			$hashed_key = md5( serialize( $field_key ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- OK use of serialize().
+
 			switch ( $field['_ctct_map_select'] ) {
 				case 'address':
-					$return[ 'street_address___' . md5( serialize( $field_key ) ) ]                     = $field_key;
-					$return[ 'street_address___' . md5( serialize( $field_key ) ) ]['_ctct_map_select'] = 'street';
+					$return[ 'street_address___' . $hashed_key ]                     = $field_key;
+					$return[ 'street_address___' . $hashed_key ]['_ctct_map_select'] = 'street';
 
-					$return[ 'line_2_address___' . md5( serialize( $field_key ) ) ]                     = $field_key;
-					$return[ 'line_2_address___' . md5( serialize( $field_key ) ) ]['_ctct_map_select'] = 'line_2';
+					$return[ 'line_2_address___' . $hashed_key ]                     = $field_key;
+					$return[ 'line_2_address___' . $hashed_key ]['_ctct_map_select'] = 'line_2';
 
-					$return[ 'city_address___' . md5( serialize( $field_key ) ) ]                     = $field_key;
-					$return[ 'city_address___' . md5( serialize( $field_key ) ) ]['_ctct_map_select'] = 'city';
+					$return[ 'city_address___' . $hashed_key ]                     = $field_key;
+					$return[ 'city_address___' . $hashed_key ]['_ctct_map_select'] = 'city';
 
-					$return[ 'state_address___' . md5( serialize( $field_key ) ) ]                     = $field_key;
-					$return[ 'state_address___' . md5( serialize( $field_key ) ) ]['_ctct_map_select'] = 'state';
+					$return[ 'state_address___' . $hashed_key ]                     = $field_key;
+					$return[ 'state_address___' . $hashed_key ]['_ctct_map_select'] = 'state';
 
-					$return[ 'zip_address___' . md5( serialize( $field_key ) ) ]                     = $field_key;
-					$return[ 'zip_address___' . md5( serialize( $field_key ) ) ]['_ctct_map_select'] = 'zip';
+					$return[ 'zip_address___' . $hashed_key ]                     = $field_key;
+					$return[ 'zip_address___' . $hashed_key ]['_ctct_map_select'] = 'zip';
 
 					break;
 				case 'anniversery':
 				case 'birthday':
-					$return[ 'month___' . md5( serialize( $field_key ) ) ]                     = $field_key;
-					$return[ 'month___' . md5( serialize( $field_key ) ) ]['_ctct_map_select'] = 'month';
+					$return[ 'month___' . $hashed_key ]                     = $field_key;
+					$return[ 'month___' . $hashed_key ]['_ctct_map_select'] = 'month';
 
-					$return[ 'day___' . md5( serialize( $field_key ) ) ]                     = $field_key;
-					$return[ 'day___' . md5( serialize( $field_key ) ) ]['_ctct_map_select'] = 'day';
+					$return[ 'day___' . $hashed_key ]                     = $field_key;
+					$return[ 'day___' . $hashed_key ]['_ctct_map_select'] = 'day';
 
-					$return[ 'year___' . md5( serialize( $field_key ) ) ]                     = $field_key;
-					$return[ 'year___' . md5( serialize( $field_key ) ) ]['_ctct_map_select'] = 'year';
+					$return[ 'year___' . $hashed_key ]                     = $field_key;
+					$return[ 'year___' . $hashed_key ]['_ctct_map_select'] = 'year';
 
 					break;
 				default:
-					$return[ $field['_ctct_map_select'] . '___' . md5( serialize( $field_key ) ) ] = $field_key;
+					$return[ $field['_ctct_map_select'] . '___' . $hashed_key ] = $field_key;
 					break;
 			}
 		}
@@ -534,6 +557,7 @@ class ConstantContact_Process_Form {
 	/**
 	 * Get field requirement errors.
 	 *
+	 * @author Brad Parbs <bradparbs@webdevstudios.com>
 	 * @since 1.0.0
 	 *
 	 * @param array $values Values.
@@ -593,6 +617,7 @@ class ConstantContact_Process_Form {
 	/**
 	 * Clean our values from form submission.
 	 *
+	 * @author Brad Parbs <bradparbs@webdevstudios.com>
 	 * @since 1.0.0
 	 *
 	 * @param array $values Values to clean.
@@ -635,9 +660,10 @@ class ConstantContact_Process_Form {
 	/**
 	 * Form submit success/error messages.
 	 *
+	 * @author Brad Parbs <bradparbs@webdevstudios.com>
 	 * @since 1.0.0
 	 *
-	 * @throws Exception
+	 * @throws Exception Throws Exception if encountered while attempting to process form wrapper.
 	 *
 	 * @param  array      $form_data Form data to process.
 	 * @param  string|int $form_id   Form ID being processed.
@@ -645,13 +671,14 @@ class ConstantContact_Process_Form {
 	 * @return false|array
 	 */
 	public function process_wrapper( $form_data = [], $form_id = 0, $instance = 0 ) {
+		$ctct_id = absint( filter_input( INPUT_POST, 'ctct-id', FILTER_SANITIZE_NUMBER_INT ) );
 
-		if ( empty( $_POST['ctct-id'] ) ) {
+		if ( empty( $ctct_id ) ) {
 			return false;
 		}
 
 		// @todo Utilize $form_data.
-		if ( isset( $_POST['ctct-id'] ) && $form_id !== absint( $_POST['ctct-id'] ) ) {
+		if ( $ctct_id !== $form_id ) {
 			return false;
 		}
 
@@ -676,12 +703,26 @@ class ConstantContact_Process_Form {
 				/**
 				 * Filters the message for the successful processed form.
 				 *
-				 * @since 1.3.0
+				 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
 				 *
-				 * @param string     $value Success message.
-				 * @param string/int $form_id ID of the Constant Contact form being submitted to.
+				 * @author Michael Beckwith <michael@webdevstudios.com>
+				 * @since  1.3.0
+				 *
+				 * @param  string     $value Success message.
+				 * @param  string/int $form_id ID of the Constant Contact form being submitted to.
 				 */
-				$message = apply_filters( 'ctct_process_form_success', __( 'Your information has been submitted.', 'constant-contact-forms' ), $form_id );
+				$message = apply_filters_deprecated( 'ctct_process_form_success', [ __( 'Your information has been submitted.', 'constant-contact-forms' ), $form_id ], 'NEXT', 'constant_contact_process_form_success' );
+
+				/**
+				 * Filters the message for the successful processed form.
+				 *
+				 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+				 * @since  NEXT
+				 *
+				 * @param  string     $value   Success message.
+				 * @param  string|int $form_id Constant Contact form ID.
+				 */
+				$message = apply_filters( 'constant_contact_process_form_success', $message, $form_id );
 				break;
 
 			case 'error':
@@ -714,6 +755,7 @@ class ConstantContact_Process_Form {
 	/**
 	 * Increment a counter for processed form submissions.
 	 *
+	 * @author Michael Beckwith <michael@webdevstudios.com>
 	 * @since 1.2.2
 	 */
 	public function increment_processed_form_count() {
@@ -725,6 +767,7 @@ class ConstantContact_Process_Form {
 	/**
 	 * Check if we have all the required fields for a given form.
 	 *
+	 * @author Michael Beckwith <michael@webdevstudios.com>
 	 * @since 1.3.5
 	 *
 	 * @param int   $form_id   ID of form to verify.
@@ -755,6 +798,7 @@ class ConstantContact_Process_Form {
 	/**
 	 * Gets the non-human error messeage dispalyed when we think there's a bot.
 	 *
+	 * @author Michael Beckwith <michael@webdevstudios.com>
 	 * @since 1.5.0
 	 * @param int $post_id The ID of the current post.
 	 * @return string
@@ -765,11 +809,26 @@ class ConstantContact_Process_Form {
 		/**
 		 * Filter the error message displayed for suspected non-humans.
 		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
+		 *
+		 * @author Michael Beckwith <michael@webdevstudios.com>
 		 * @since 1.5.0
 		 * @param string $error The error message dispalyed.
 		 * @param mixed  $post_id The ID of the current post.
 		 * @return string
 		 */
-		return apply_filters( 'ctct_custom_spam_message', $error, $post_id );
+		$error = apply_filters_deprecated( 'ctct_custom_spam_message', [ $error, $post_id ], 'NEXT', 'constant_contact_custom_spam_message' );
+
+		/**
+		 * Filters error message for suspected spam entries.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param  string     $error   Error message.
+		 * @param  int|string $post_id Current post ID.
+		 * @return string              Error message.
+		 */
+		return apply_filters( 'constant_contact_custom_spam_message', $error, $post_id );
 	}
 }

--- a/includes/class-recaptcha-v2.php
+++ b/includes/class-recaptcha-v2.php
@@ -11,6 +11,8 @@
  * phpcs:disable WebDevStudios.All.RequireAuthor -- Don't require author tag in docblocks.
  */
 
+// phpcs:disable PEAR.NamingConventions.ValidClassName.Invalid -- OK classname.
+
 /**
  * Class ConstantContact_reCAPTCHA_v2
  *
@@ -30,8 +32,6 @@ class ConstantContact_reCAPTCHA_v2 extends ConstantContact_reCAPTCHA {
 	 * Retrieve inline scripts for the reCAPTCHA form instance.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return string
 	 */
 	public function enqueue_scripts() {
 		$debug  = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG === true );
@@ -86,6 +86,16 @@ class ConstantContact_reCAPTCHA_v2 extends ConstantContact_reCAPTCHA {
 		$this->recaptcha_size = $size;
 	}
 
+	/**
+	 * Add script attributes.
+	 *
+	 * @author Michael Beckwith <michael@webdevstudios.com>
+	 * @since  1.8.3
+	 *
+	 * @param  string $tag    Script tag.
+	 * @param  string $handle Script handle.
+	 * @return string         Script tag.
+	 */
 	public function add_script_attributes( $tag, $handle ) {
 		if ( 'recaptcha-lib-v2' !== $handle ) {
 			return $tag;

--- a/includes/class-recaptcha-v3.php
+++ b/includes/class-recaptcha-v3.php
@@ -11,6 +11,8 @@
  * phpcs:disable WebDevStudios.All.RequireAuthor -- Don't require author tag in docblocks.
  */
 
+// phpcs:disable PEAR.NamingConventions.ValidClassName.Invalid -- OK classname.
+
 /**
  * Class ConstantContact_reCAPTCHA_v3
  *

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -9,6 +9,8 @@
  * phpcs:disable WebDevStudios.All.RequireAuthor -- Don't require author tag in docblocks.
  */
 
+// phpcs:disable PEAR.NamingConventions.ValidClassName.Invalid -- OK classname.
+
 /**
  * Class ConstantContact_reCAPTCHA.
  *
@@ -95,8 +97,8 @@ class ConstantContact_reCAPTCHA {
 	 * @return bool
 	 */
 	public static function has_recaptcha_keys() {
-		$site_key   = ctct_get_settings_option( '_ctct_recaptcha_site_key', '' );
-		$secret_key = ctct_get_settings_option( '_ctct_recaptcha_secret_key', '' );
+		$site_key   = constant_contact_get_option( '_ctct_recaptcha_site_key', '' );
+		$secret_key = constant_contact_get_option( '_ctct_recaptcha_secret_key', '' );
 
 		return $site_key && $secret_key;
 	}
@@ -110,8 +112,8 @@ class ConstantContact_reCAPTCHA {
 	 */
 	public function get_recaptcha_keys() {
 		$keys               = [];
-		$keys['site_key']   = ctct_get_settings_option( '_ctct_recaptcha_site_key', '' );
-		$keys['secret_key'] = ctct_get_settings_option( '_ctct_recaptcha_secret_key', '' );
+		$keys['site_key']   = constant_contact_get_option( '_ctct_recaptcha_site_key', '' );
+		$keys['secret_key'] = constant_contact_get_option( '_ctct_recaptcha_secret_key', '' );
 
 		return $keys;
 	}
@@ -149,6 +151,6 @@ class ConstantContact_reCAPTCHA {
 	 * @since 1.7.0
 	 */
 	public function set_recaptcha_version() {
-		$this->version = ctct_get_settings_option( '_ctct_recaptcha_version', '' );
+		$this->version = constant_contact_get_option( '_ctct_recaptcha_version', '' );
 	}
 }

--- a/includes/class-shortcode.php
+++ b/includes/class-shortcode.php
@@ -36,6 +36,7 @@ class ConstantContact_Shortcode {
 	/**
 	 * Plugin object.
 	 *
+	 * @since 1.6.0
 	 * @var Constant_Contact
 	 */
 	public $plugin;

--- a/includes/class-uninstall.php
+++ b/includes/class-uninstall.php
@@ -87,11 +87,23 @@ class ConstantContact_Uninstall {
 		/**
 		 * Allows filtering which options are deleted upon plugin deactivation.
 		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
+		 *
 		 * @since 1.6.0
 		 *
 		 * @param array $options One-dimensional array of option names to delete.
 		 */
-		return apply_filters( 'ctct_option_names_to_uninstall', $this->options );
+		$options = apply_filters_deprecated( 'ctct_option_names_to_uninstall', [ $this->options ], 'NEXT', 'constant_contact_option_names_to_uninstall' );
+
+		/**
+		 * Filters which options are deleted when plugin is uninstalled.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param  array $options Options to be deleted.
+		 */
+		return apply_filters( 'constant_contact_option_names_to_uninstall', $options );
 	}
 
 	/**
@@ -112,11 +124,23 @@ class ConstantContact_Uninstall {
 		/**
 		 * Allows filtering which transients are deleted upon plugin deactivation.
 		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
+		 *
 		 * @since 1.6.0
 		 *
 		 * @param array $transients One-dimensional array of transient names to delete.
 		 */
-		return apply_filters( 'ctct_transient_names_to_uninstall', $this->transients );
+		$transients = apply_filters_deprecated( 'ctct_transient_names_to_uninstall', [ $this->transients ], 'NEXT', 'constant_contact_transient_names_to_uninstall' );
+
+		/**
+		 * Filters which transients are deleted when plugin is uninstalled.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param  array $transients Transients to be deleted.
+		 */
+		return apply_filters( 'constant_contact_transient_names_to_uninstall', $transients );
 	}
 
 	/**
@@ -134,11 +158,23 @@ class ConstantContact_Uninstall {
 		/**
 		 * Allows filtering which cron hooks are deleted upon plugin deactivation.
 		 *
+		 * @deprecated NEXT Deprecated in favor of properly-prefixed hookname.
+		 *
 		 * @since 1.6.0
 		 *
 		 * @param array $cron_hooks One-dimensional array of cron hook names to delete.
 		 */
-		return apply_filters( 'ctct_cron_hook_names_to_uninstall', $this->cron_hooks );
+		$cron_hooks = apply_filters_deprecated( 'ctct_cron_hook_names_to_uninstall', [ $this->cron_hooks ], 'NEXT', 'constant_contact_cron_hook_names_to_uninstall' );
+
+		/**
+		 * Filters which cron hooks are deleted when plugin is uninstalled.
+		 *
+		 * @author Rebekah Van Epps <rebekah.vanepp@webdevstudios.com>
+		 * @since  NEXT
+		 *
+		 * @param  array $cron_hooks Cron hooks to be deleted.
+		 */
+		return apply_filters( 'constant_contact_cron_hook_names_to_uninstall', $cron_hooks );
 	}
 
 	/**

--- a/includes/class-user-customizations.php
+++ b/includes/class-user-customizations.php
@@ -43,7 +43,7 @@ class ConstantContact_User_Customizations {
 	 * @since 1.3.0
 	 */
 	public function hooks() {
-		add_filter( 'ctct_process_form_success', [ $this, 'process_form_success' ], 10, 2 );
+		add_filter( 'constant_contact_process_form_success', [ $this, 'process_form_success' ], 10, 2 );
 		add_filter( 'constant_contact_front_form_action', [ $this, 'custom_redirect' ], 10, 2 );
 		add_filter( 'constant_contact_destination_email', [ $this, 'custom_email' ], 10, 2 );
 	}

--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -81,7 +81,7 @@ function constant_contact_wpspamshield_compatibility( $ignored_keys = [], $form_
 
 	// This will grab all of the keys from the global $_POST, and then assign
 	// the difference between that and our intended keys.
-	$bad_keys = array_diff( array_keys( $_POST ), $good_keys ); // WPCS: CSRF ok.
+	$bad_keys = array_diff( array_keys( $_POST ), $good_keys ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- CSRF OK.
 
 	// This will merge the passed ignored keys with our newly found bad keys,
 	// and then return all the unique values for our return value.

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Deprecated functions.
+ *
+ * @package Constantcontact
+ * @author  Constant Contact
+ * @since   NEXT
+ *
+ * phpcs:disable WebDevStudios.All.RequireAuthor -- Don't require author tag in docblocks.
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Incorrectly prefixed functions have been deprecated.
+ */
+
+/**
+ * Wrapper function around cmb2_get_option.
+ *
+ * @deprecated NEXT Deprecated in favor of properly-prefixed function name.
+ *
+ * @since  1.0.0
+ *
+ * @param  string $key     Options array key.
+ * @param  string $default Default value if no option exists.
+ * @return mixed           Option value.
+ */
+function ctct_get_settings_option( $key = '', $default = null ) {
+	_deprecated_function( __FUNCTION__, 'NEXT', 'constant_contact_get_option' );
+
+	return constant_contact_get_option( $key, $default );
+}
+
+/**
+ * Process potential custom Constant Contact Forms action urls.
+ *
+ * @deprecated NEXT Deprecated in favor of properly-prefixed function name.
+ *
+ * @since  1.2.3
+ *
+ * @throws Exception Throw Exception if error occurs during form processing.
+ *
+ * @return bool|array
+ */
+function ctct_custom_form_action_processing() {
+	_deprecated_function( __FUNCTION__, 'NEXT', 'constant_contact_process_form_custom' );
+
+	return constant_contact_process_form_custom();
+}
+
+/**
+ * Determine if we have any Constant Contact Forms published.
+ *
+ * @deprecated NEXT Deprecated in favor of properly-prefixed function name.
+ *
+ * @since 1.2.5
+ *
+ * @return bool
+ */
+function ctct_has_forms() {
+	_deprecated_function( __FUNCTION__, 'NEXT', 'constant_contact_has_forms' );
+
+	return constant_contact_has_forms();
+}

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -196,8 +196,8 @@ function constant_contact_maybe_display_exceptions_notice() {
  * @since 1.2.0
  */
 function constant_contact_optin_ajax_handler() {
-
-	$optin = filter_var( $_REQUEST['optin'], FILTER_SANITIZE_STRING );
+	$optin = filter_input( INPUT_GET, 'optin', FILTER_SANITIZE_STRING );
+	$optin = empty( $optin ) ? filter_input( INPUT_POST, 'optin', FILTER_SANITIZE_STRING ) : $optin;
 
 	if ( 'on' !== $optin ) {
 		wp_send_json_success( [ 'opted-in' => 'off' ] );
@@ -218,8 +218,9 @@ add_action( 'wp_ajax_constant_contact_optin_ajax_handler', 'constant_contact_opt
  * @since 1.2.0
  */
 function constant_contact_privacy_ajax_handler() {
+	$agreed = filter_input( INPUT_GET, 'privacy_agree', FILTER_SANITIZE_STRING );
+	$agreed = empty( $agreed ) ? filter_input( INPUT_POST, 'privacy_agree', FILTER_SANITIZE_STRING ) : $agreed;
 
-	$agreed = filter_var( $_REQUEST['privacy_agree'], FILTER_SANITIZE_STRING );
 	update_option( 'ctct_privacy_policy_status', $agreed );
 
 	wp_send_json_success( [ 'updated' => 'true' ] );
@@ -269,16 +270,14 @@ function constant_contact_review_ajax_handler() {
 add_action( 'wp_ajax_constant_contact_review_ajax_handler', 'constant_contact_review_ajax_handler' );
 
 /**
- * Process potential custom Constant Contact Forms action urls.
+ * Perform custom form processing.
  *
- * @since 1.2.3
+ * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+ * @since  NEXT
  *
- * @throws Exception
- *
- * @return bool|array
+ * @return mixed Results of form processing, false if no processing performed.
  */
-function ctct_custom_form_action_processing() {
-
+function constant_contact_process_form_custom() {
 	$ctct_id = filter_input( INPUT_POST, 'ctct-id', FILTER_VALIDATE_INT );
 
 	if ( false === $ctct_id ) {
@@ -291,22 +290,24 @@ function ctct_custom_form_action_processing() {
 
 	return constant_contact()->process_form->process_form();
 }
-add_action( 'wp_head', 'ctct_custom_form_action_processing' );
+add_action( 'wp_head', 'constant_contact_process_form_custom' );
 
 /**
- * Determine if we have any Constant Contact Forms published.
+ * Check if any published Constant Contact forms exist.
  *
- * @since 1.2.5
+ * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+ * @since  NEXT
  *
- * @return bool
+ * @return bool Whether published forms exist.
  */
-function ctct_has_forms() {
+function constant_contact_has_forms() {
 	$args  = [
 		'post_type'      => 'ctct_forms',
 		'post_status'    => 'publish',
 		'posts_per_page' => 1,
 	];
 	$forms = new WP_Query( $args );
+
 	return $forms->have_posts();
 }
 
@@ -384,7 +385,7 @@ function constant_contact_clean_url( $url = '' ) {
  * @return bool
  */
 function constant_contact_debugging_enabled() {
-	$debugging_enabled = ctct_get_settings_option( '_ctct_logging', '' );
+	$debugging_enabled = constant_contact_get_option( '_ctct_logging', '' );
 
 	if ( apply_filters( 'constant_contact_force_logging', false ) ) {
 		$debugging_enabled = 'on';
@@ -567,7 +568,7 @@ function constant_contact_emails_disabled( $form_id = 0 ) {
 		$disabled = true;
 	}
 
-	$global_form_disabled = ctct_get_settings_option( '_ctct_disable_email_notifications', '' );
+	$global_form_disabled = constant_contact_get_option( '_ctct_disable_email_notifications', '' );
 	if ( 'on' === $global_form_disabled ) {
 		$disabled = true;
 	}
@@ -626,7 +627,7 @@ function constant_contact_get_css_customization( $form_id, $customization_key = 
 		}
 	}
 
-	$global_setting = ctct_get_settings_option( $customization_key );
+	$global_setting = constant_contact_get_option( $customization_key );
 
 	return ! empty( $global_setting ) ? $global_setting : '';
 }
@@ -657,7 +658,7 @@ function constant_contact_privacy_policy_content() {
  *
  * @since 1.6.0
  *
- * @param string $status Status value to set
+ * @param string $status Status value to set.
  */
 function constant_contact_set_has_exceptions( $status = 'true' ) {
 	update_option( 'ctct_exceptions_exist', $status );
@@ -735,7 +736,7 @@ function constant_contact_get_widgets_by_form( $form_id ) {
 		$widgets = array_filter( get_option( "widget_{$widget_type}", [] ), function( $value ) use ( $data ) {
 			if ( 'ctct_form' === $data['type'] ) {
 				return absint( $value['ctct_form_id'] ) === $data['form_id'];
-			} else if ( 'text' === $data['type'] ) {
+			} elseif ( 'text' === $data['type'] ) {
 				if ( ! isset( $value['text'] ) || false === strpos( $value['text'], '[ctct' ) ) {
 					return false;
 				}
@@ -744,7 +745,7 @@ function constant_contact_get_widgets_by_form( $form_id ) {
 			return false;
 		} );
 		array_walk( $widgets, 'constant_contact_walk_widget_references', $widget_type );
-		$return  = array_merge( $return, $widgets );
+		$return = array_merge( $return, $widgets );
 	}
 
 	return $return;
@@ -763,11 +764,11 @@ function constant_contact_get_widgets_by_form( $form_id ) {
 function constant_contact_walk_widget_references( array &$value, $key, $type ) {
 	global $wp_registered_sidebars, $wp_registered_widgets;
 
-	$widget_id  = "{$type}-{$key}";
-	$sidebars   = array_keys( array_filter( get_option( 'sidebars_widgets', [] ), function( $sidebar ) use ( $widget_id ) {
-		return is_array( $sidebar ) && in_array( $widget_id, $sidebar );
+	$widget_id = "{$type}-{$key}";
+	$sidebars  = array_keys( array_filter( get_option( 'sidebars_widgets', [] ), function( $sidebar ) use ( $widget_id ) {
+		return is_array( $sidebar ) && in_array( $widget_id, $sidebar, true );
 	} ) );
-	$value = [
+	$value     = [
 		'type'    => 'widget',
 		'widget'  => $type,
 		'url'     => admin_url( 'widgets.php' ),

--- a/includes/widgets/contact-form-select.php
+++ b/includes/widgets/contact-form-select.php
@@ -112,16 +112,17 @@ class ConstantContactWidget extends WP_Widget {
 		$title           = trim( wp_strip_all_tags( $instance['ctct_title'] ) );
 		$form_id         = absint( $instance['ctct_form_id'] );
 		$show_form_title = ( ! empty( $instance['ctct_form_title'] ) ) ? 'true' : 'false';
-
-		echo $args['before_widget']; // WPCS: XSS Ok.
+		$widget          = $args['before_widget'];
 
 		if ( $title ) {
-			echo $args['before_title'] . esc_html( $title ) . $args['after_title']; // WPCS: XSS Ok.
+			$widget .= $args['before_title'] . esc_html( $title ) . $args['after_title'];
 		}
 
-		echo do_shortcode( sprintf( '[ctct form="%s" show_title="%s"]', $form_id, $show_form_title ) );
+		$widget .= do_shortcode( sprintf( '[ctct form="%s" show_title="%s"]', $form_id, $show_form_title ) );
 
-		echo $args['after_widget']; // WPCS: XSS Ok.
+		$widget .= $args['after_widget'];
+
+		echo $widget; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- XSS OK.
 	}
 
 	/**
@@ -238,13 +239,14 @@ class ConstantContactWidget extends WP_Widget {
 					);
 				}
 			}
+
 			printf(
 				'<p><label for="%1$s">%2$s</label><select class="widefat" name="%3$s" id="%4$s">%5$s</select>',
 				esc_attr( $name ),
 				esc_html( $label_text ),
 				esc_attr( $name ),
 				esc_attr( $id ),
-				$selects
+				$selects // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- XSS OK.
 			);
 		}
 	}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -53,4 +53,9 @@
 	<exclude-pattern>/tests/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
 
+	<!-- Ignore InvalidClassFileName warnings. -->
+	<rule ref="WordPress.Files.FileName">
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+	</rule>
+
 </ruleset>


### PR DESCRIPTION
There were numerous PHPCS cleanup fixes on [`sprint/20.07` branch](https://github.com/WebDevStudios/constant-contact-forms/commits/sprint/20.07) that were missing from `sprint/20.08`.

 I've merged `sprint/20.07` and `sprint/20.08` locally, and resolved the conflicts. This PR back to `sprint/20.08` is the result.

```
$ composer lint
> @php ./vendor/squizlabs/php_codesniffer/bin/phpcs --standard=phpcs.xml.dist
................. 17 / 17 (100%)


Time: 410ms; Memory: 14Mb

$ composer compat
> @php ./vendor/squizlabs/php_codesniffer/bin/phpcs --standard=phpcompat.xml.dist
................. 17 / 17 (100%)


Time: 306ms; Memory: 8Mb
```