### PR TITLE
Escaping HTML output on button label, button placeholder and success message

### DIFF
--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -969,7 +969,7 @@ class ConstantContact_Display {
 
 		$type     = sanitize_text_field( $type );
 		$value    = sanitize_text_field( $value );
-		$label    = sanitize_text_field( $label );
+		$label    = esc_html( sanitize_text_field( $label ) );
 		$req_text = $req ? 'required' : '';
 
 		$markup = $this->field_top( $type, $name, $field_key, $label, $req );
@@ -1136,7 +1136,7 @@ class ConstantContact_Display {
 			'type'   => 'submit',
 			'name'   => 'ctct-submitted',
 			'map_to' => 'ctct-submitted',
-			'value'  => $button_text,
+			'value'  => esc_html( $button_text ),
 		] );
 	}
 

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -111,9 +111,9 @@ class ConstantContact_Process_Form {
 
 				case 'success':
 					/** This filter is documented in includes/class-process-form.php */
-					$message = apply_filters( 'ctct_process_form_success',
+					$message = esc_html ( apply_filters( 'ctct_process_form_success',
 						__( 'Your information has been submitted.', 'constant-contact-forms' ),
-						(int) $json_data['ctct-id'] );
+						(int) $json_data['ctct-id'] ) );
 					break;
 
 				case 'error':
@@ -653,7 +653,7 @@ class ConstantContact_Process_Form {
 				 * @param string     $value Success message.
 				 * @param string/int $form_id ID of the Constant Contact form being submitted to.
 				 */
-				$message = apply_filters( 'ctct_process_form_success', __( 'Your information has been submitted.', 'constant-contact-forms' ), $form_id );
+				$message = esc_html ( apply_filters( 'ctct_process_form_success', __( 'Your information has been submitted.', 'constant-contact-forms' ), $form_id ) );
 				break;
 
 			case 'error':


### PR DESCRIPTION
Ticket: [CC-195](https://webdevstudios.atlassian.net/browse/CC-195)

**Description**
Fixes authenticate user exploit in Add New Form controls by escaping (`esc_html`) the output.

**Steps to Verify**
Follow step #3 in the [original ticket](https://webdevstudios.atlassian.net/browse/CC-195)
