### PR TITLE
CC-196: Allow users to choose list -- Fix for non-connected CC accounts

### DIFF
--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -515,7 +515,7 @@ class ConstantContact_Display {
 			}
 		}
 
-		if ( isset( $form_data['options'] ) ) {
+		if ( constant_contact()->api->is_connected() && isset( $form_data['options'] ) ) {
 			$lists = maybe_unserialize( isset( $form_data['options']['optin']['list'] ) ? $form_data['options']['optin']['list'] : '' );
 
 			$return .= $this->field( [

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -353,7 +353,7 @@ class ConstantContact_Process_Form {
 		$cleaned_values = $this->clean_values( $return['values'] );
 
 		// Require at least one list to be selected.
-		if ( ! isset( $cleaned_values['ctct-lists'] ) || empty( $cleaned_values['ctct-lists'] ) ) {
+		if ( constant_contact()->api->is_connected() && ( ! isset( $cleaned_values['ctct-lists'] ) || empty( $cleaned_values['ctct-lists'] ) ) ) {
 			return [
 				'status' => 'named_error',
 				'error'  => __( 'Please select at least one list to subscribe to.', 'constant-contact-forms' ),


### PR DESCRIPTION
Ticket: [CC-196](https://webdevstudios.atlassian.net/browse/CC-196)

### Description ###

Fixes list selection process (per CC-36):
- List selection field should only appear when CC account is connected; check/error messages related to this field should likewise only appear if CC account is connected.

### Screenshot ###

![Screen Shot 2020-07-06 at 4 54 02 PM](https://user-images.githubusercontent.com/36422618/86805042-bf632680-c034-11ea-98b8-341e1417da3d.png)

### Steps to verify the solution ###

1. With no CC account connected, confirm form(s) submit with no error messages relating to list selection.
2. Check email or use mail logging to confirm form was submitted successfully.
3. With CC account connected, add multiple list options to a form.
4. On frontend, confirm list selection error message displays if no lists selected.
5. Confirm form submits with no error message if at least one list is selected.
6. Log into Constant Contact account and confirm a) submissions were successful, and b) contact was added to all lists selected. (Note: Selecting "Bypass Constant Contact cron scheduling" in Contact Form settings is useful to avoid delays in submission.)