### PR TITLE
CC-200 Elementor Widget

### DIFF
--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -331,6 +331,14 @@ class Constant_Contact {
 	private $gutenberg;
 
 	/**
+	 * An instance of the ConstantContact_Elementor class.
+	 *
+	 * @since 1.5.0
+	 * @var ConstantContact_Elementor
+	 */
+	private $elementor;
+
+	/**
 	 * Option name for where we store the timestamp of when the plugin was activated.
 	 *
 	 * @since 1.6.0
@@ -437,6 +445,7 @@ class Constant_Contact {
 		$this->optin                = new ConstantContact_Optin( $this );
 		$this->logging              = new ConstantContact_Logging( $this );
 		$this->customizations       = new ConstantContact_User_Customizations( $this );
+		$this->elementor            = new ConstantContact_Elementor( $this );
 	}
 
 	/**
@@ -619,6 +628,7 @@ class Constant_Contact {
 			case 'customizations':
 			case 'display':
 			case 'display_shortcode':
+			case 'elementor':
 			case 'gutenberg':
 			case 'lists':
 			case 'logging':

--- a/includes/class-elementor.php
+++ b/includes/class-elementor.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Elementor Support
+ *
+ * @package ConstantContact
+ * @subpackage Elementor
+ * @author Constant Contact
+ * @since NEXT
+ *
+ * phpcs:disable WebDevStudios.All.RequireAuthor -- Don't require author tag in docblocks.
+ */
+
+/**
+ * This class get's everything up an running for Elementor support.
+ *
+ * @since NEXT
+ */
+class ConstantContact_Elementor {
+
+	/**
+	 * Parent plugin class.
+	 *
+	 * @since NEXT
+	 * @var object
+	 */
+	protected $plugin;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since NEXT
+	 *
+	 * @param object $plugin Parent plugin.
+	 */
+	public function __construct( $plugin ) {
+		$this->plugin = $plugin;
+		$this->hooks();
+	}
+
+	/**
+	 * Register Hooks
+	 *
+	 * @since  NEXT
+	 */
+	private function hooks() {
+		add_action( 'elementor/widgets/widgets_registered', [ $this, 'register_widget' ] );
+	}
+
+	/**
+	 * Registers all Elementor Widgets
+	 *
+	 * @since  NEXT
+	 */
+	public function register_widget() {
+		require_once( __DIR__ . '/widgets/elementor-widget.php' );
+		\Elementor\Plugin::instance()->widgets_manager->register_widget_type( new ConstantContact_Elementor_Widget() );
+	}
+
+}

--- a/includes/widgets/elementor-widget.php
+++ b/includes/widgets/elementor-widget.php
@@ -32,7 +32,7 @@ class ConstantContact_Elementor_Widget extends \Elementor\Widget_Base {
 	 * @since  NEXT
 	 */
 	public function get_title() {
-		return 'Constant Contact';
+		return 'Constant Contact Form';
 	}
 
 	/**
@@ -41,7 +41,7 @@ class ConstantContact_Elementor_Widget extends \Elementor\Widget_Base {
 	 * @since  NEXT
 	 */
 	public function get_icon() {
-		return 'fa fa-code';
+		return 'eicon-form-horizontal';
 	}
 	
 	/**

--- a/includes/widgets/elementor-widget.php
+++ b/includes/widgets/elementor-widget.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Elementor Widget
+ *
+ * @package ConstantContact
+ * @subpackage Elementor
+ * @author Constant Contact
+ * @since NEXT
+ *
+ * phpcs:disable WebDevStudios.All.RequireAuthor -- Don't require author tag in docblocks.
+ */
+
+/**
+ * This class get's everything up an running for Elementor Widget.
+ *
+ * @since NEXT
+ */
+class ConstantContact_Elementor_Widget extends \Elementor\Widget_Base {
+
+	/**
+	 * Widgets Name
+	 *
+	 * @since  NEXT
+	 */
+	public function get_name() {
+		return 'constant-contact';
+	}
+	
+	/**
+	 * Widgets Title
+	 *
+	 * @since  NEXT
+	 */
+	public function get_title() {
+		return 'Constant Contact';
+	}
+
+	/**
+	 * Widgets Icon
+	 *
+	 * @since  NEXT
+	 */
+	public function get_icon() {
+		return 'fa fa-code';
+	}
+	
+	/**
+	 * Widgets Category
+	 *
+	 * @since  NEXT
+	 */
+	public function get_categories() {
+		return [ 'basic' ];
+	}
+	
+	/**
+	 * Displays Widget Controls.
+	 *
+	 * @since  NEXT
+	 */
+	protected function _register_controls() {
+
+		$this->start_controls_section(
+			'section_title',
+			[
+				'label' => __( 'Constant Contact Form Settings', 'constant-contact-forms' ),
+			]
+		);
+		
+		$this->add_control(
+			'show_title',
+			[
+				'label'        => __( 'Show Title', 'constant-contact-forms' ),
+				'type'         => \Elementor\Controls_Manager::SWITCHER,
+				'label_on'     => __( 'Show', 'constant-contact-forms' ),
+				'label_off'    => __( 'Hide', 'constant-contact-forms' ),
+				'return_value' => true,
+				'default'      => true,
+			]
+		);
+
+		$this->add_control(
+			'form_id',
+			[
+				'label' => __( 'Form', 'constant-contact-forms' ),
+				'type' => \Elementor\Controls_Manager::SELECT,
+				'options' => $this->get_form_options(),
+			]
+		);
+
+		$this->end_controls_section();
+	}
+
+	/**
+	 * Provides all Constant Contact Forms current Published.
+	 *
+	 * @since  NEXT
+	 */
+	private function get_form_options () {
+
+		$options = [
+
+		];
+
+		$forms = get_posts([
+			'post_type' => 'ctct_forms',
+			'post_status' => 'publish',
+			'numberposts' => -1
+		]);
+
+		foreach ( $forms as $form ) {
+			$options[ $form->ID ] = $form->post_title;
+		}
+
+		if ( empty( $options ) ) {
+			$options[ '' ] = __( 'No forms currently published.', 'constant-contact-forms' );
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Displays Widget
+	 *
+	 * @since  NEXT
+	 */
+	protected function render() {
+		$settings = $this->get_settings_for_display();
+
+		if ( empty( $settings['form_id'] ) ) {
+			echo __( 'Please select a form.', 'constant-contact-forms' );
+			return;
+		}
+
+		$show_title = $settings['show_title'] ? 'true' : 'false';
+		echo do_shortcode( "[ctct form='{$settings['form_id']}' show_title='{$show_title}']" );
+	}
+	
+}


### PR DESCRIPTION
Adds a dedicated Elementor Widget.

To validate.
1. Install the base version of the Elementor plugin.
2. Attempt to add a constant contact form widget. (Support for toggling the form title).

![2020-10-28 08 47 39](https://user-images.githubusercontent.com/17047900/97438002-9d025b00-18fa-11eb-80ae-cd5af3b5eabc.gif)
