### PR TITLE
CC-203 Additional tooltips

### DIFF
--- a/includes/class-builder-fields.php
+++ b/includes/class-builder-fields.php
@@ -216,10 +216,19 @@ class ConstantContact_Builder_Fields {
 			] );
 
 			$lists = $this->plugin->builder->get_lists();
+			
+			if ( empty( $lists ) ) {
+				$list_metabox->add_field( array(
+					'name' => esc_html__( 'No Lists Found', 'constant-contact-forms' ),
+					'desc' => '<a href="/wp-admin/edit.php?post_type=ctct_lists">' .esc_html__( 'Create a List', 'constant-contact-forms' ) . '</a>',
+					'type' => 'title',
+					'id'   => $this->prefix . 'tip',
+				) );
+			}
 
 			if ( $lists ) {
 				$list_metabox->add_field( [
-					'name'    => esc_html__( 'Allow subscribers to select from lists', 'constant-contact-forms' ),
+					'name'    => esc_html__( 'Allow subscribers to select from lists. ( Select at least one )', 'constant-contact-forms' ),
 					'id'      => $this->prefix . 'list',
 					'type'    => 'multicheck',
 					'options' => $lists,


### PR DESCRIPTION
https://webdevstudios.atlassian.net/browse/CC-203

The user reports confusion when first creating a form that they didn't know a list needed to be selected. Added messaging to remind users to select at least one. Additionally in the event, no list exists a help links to the list creation page.

No Lists Exist
![image](https://user-images.githubusercontent.com/17047900/102529834-7648e100-406e-11eb-9d3a-757eda131ea5.png)


List Do Exist
![image](https://user-images.githubusercontent.com/17047900/102529866-8496fd00-406e-11eb-9f6a-2652c8ec3a56.png)
