### PR TITLE
CSC-219 Disables Adds option to disable frontend css.

### DIFF
--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -801,6 +801,11 @@ class Constant_Contact {
 	 * @since 1.4.0
 	 */
 	public function register_front_assets() {
+
+		if ( disable_frontend_css() ) {
+			return;
+		}
+
 		wp_register_style(
 			'ctct_form_styles',
 			self::url() . 'assets/css/style.css',

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -476,6 +476,14 @@ class ConstantContact_Settings {
 				'constant-contact-forms'
 			),
 		] );
+
+		$cmb->add_field( [
+			'name'       => esc_html__( 'Disable Constant Contact CSS', 'constant-contact-forms' ),
+			'desc'       => esc_html__( 'Disables Constant Contact stylesheets from loading on the frontend. Note you may need to clear server and client cache to see changes go into effect.', 'constant-contact-forms' ),
+			'id'         => '_ctct_disable_css',
+			'type'       => 'checkbox',
+		] );
+		
 	}
 
 	/**
@@ -1067,4 +1075,15 @@ function constant_contact_get_option( $key = '', $default = null ) {
 	}
 
 	return $value;
+}
+
+/**
+ * Returns whether frontend css should be disabled or not.
+ *
+ * @author Scott Anderson <scott.anderson@webdevstudios.com>
+ * @since  NEXT
+ * @return bool
+ */
+function disable_frontend_css() {
+	return 'on' === constant_contact_get_option( '_ctct_disable_css' );
 }


### PR DESCRIPTION
**Closes:** https://webdevstudios.atlassian.net/browse/CC-219

### Description 
Adds Global CSS option to disable frontend CSS all together. When enabled frontend styles will not load.

![image](https://user-images.githubusercontent.com/17047900/105406573-98e49180-5bfa-11eb-9371-d06a13e05042.png)

![image](https://user-images.githubusercontent.com/17047900/105406491-823e3a80-5bfa-11eb-8073-318c11ec8705.png)


