### PR TITLE
Legal text change from sub to small.

### DIFF
--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -1860,7 +1860,7 @@ class ConstantContact_Display {
 		return apply_filters(
 			'constant_contact_disclose',
 			sprintf(
-				'<div class="ctct-disclosure" style="%s"><hr><sub>%s</sub></div>',
+				'<div class="ctct-disclosure" style="%s"><hr><small>%s</small></div>',
 				esc_attr( $this->get_inline_font_color() ),
 				$this->get_inner_disclose_text() ) );
 	}


### PR DESCRIPTION
Ticket: https://webdevstudios.atlassian.net/browse/CC-226 change the surrounding script to small. Testing on multiple themes showed design looks good. Note: if a user has explicitly targeted using `sub` as a selector they'll be forced to make changes.