### PR TITLE
Added filters to change State and Zip Code labels.

### DIFF
--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -1380,8 +1380,8 @@ class ConstantContact_Display {
 		$street   = esc_html__( 'Street Address', 'constant-contact-forms' );
 		$line_2   = esc_html__( 'Address Line 2', 'constant-contact-forms' );
 		$city     = esc_html__( 'City', 'constant-contact-forms' );
-		$state    = esc_html__( 'State', 'constant-contact-forms' );
-		$zip      = esc_html__( 'ZIP Code', 'constant-contact-forms' );
+		$state    = apply_filters( 'constant_contact_address_state', esc_html__( 'State', 'constant-contact-forms' ) );
+		$zip      = apply_filters( 'constant_contact_address_zip_code', esc_html__( 'ZIP Code', 'constant-contact-forms' ) );
 
 		$v_street = isset( $value['street_address'] ) ? $value['street_address'] : '';
 		$v_line_2 = isset( $value['line_2_address'] ) ? $value['line_2_address'] : '';


### PR DESCRIPTION
Ticket: https://webdevstudios.atlassian.net/browse/CC-228

Description
Added two filters for user to be ably to override state and zipcode labels.


Example
In `functions.php` file of twentytwenty labels are overrideable
```
function change_state( $state ) {
	return 'Province';
}

add_filter( 'constant_contact_address_state', 'change_state' );


function change_zip( $state ) {
	return 'Postal Code';
}

add_filter( 'constant_contact_address_zip_code', 'change_zip' );
```

Before
![image](https://user-images.githubusercontent.com/17047900/127904802-938f7f08-f7cb-4a0c-8e3d-990aa63a43ec.png)

After
![image](https://user-images.githubusercontent.com/17047900/127904766-dbd7ae3d-adfe-4df1-aadd-8df627d7fe6b.png)
