### PR TITLE
CC-254 Remove erroneous label markup

### DIFF
--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -1801,7 +1801,7 @@ class ConstantContact_Display {
 		$return            = '<p class="' . implode( ' ', $classes ) . '">';
 		$label             = '<span class="' . $label_placement_class . '"><label for="' . esc_attr( $field_id ) . '">' . esc_attr( $name ) . ' ' . $req_label . '</label></span>';
 		$textarea          = '<textarea class="' . esc_attr( implode( ' ', $textarea_classes ) ) . '" ' . $req_text . ' name="' . esc_attr( $map ) . '" id="' . esc_attr( $field_id ) . '" placeholder="' . esc_attr( $desc ) . '" ' . $extra_attrs . '>' . esc_html( $value ) . '</textarea>';
-		$instructions_span = '<span class="ctct-textarea-warning-label"><label for="' . esc_attr( $field_id ) . '">' . esc_html__( 'Limit 500 Characters', 'constant-contact-forms' ) . ' ' . $req_label . '</label></span>';
+		$instructions_span = '<span class="ctct-textarea-warning-label">' . esc_html__( 'Limit 500 Characters', 'constant-contact-forms' ) . '</span>';
 
 		if ( 'top' === $label_placement || 'left' === $label_placement || 'hidden' === $label_placement ) {
 			$return .= $label . $textarea;


### PR DESCRIPTION
CC-254 Remove erroneous label markup

After I approved and merge #558 I noticed that there was a second <label> element in the 500 character limit notice.

This PR resolves that.

Before:
```
<p class="ctct-form-field">
    <span class="ctct-label-top">
        <label for="custom_text_area___99a6a1bc9800303822f0b441fd116a95_0">
            Custom Text Area 
        </label>
    </span>
    <textarea class="ctct-textarea ctct-label-top" name="custom_text_area___99a6a1bc9800303822f0b441fd116a95"
              id="custom_text_area___99a6a1bc9800303822f0b441fd116a95_0" placeholder="" maxlength="500">
    </textarea>
    <span class="ctct-textarea-warning-label">
        <label for="custom_text_area___99a6a1bc9800303822f0b441fd116a95_0">
            Limit 500 Characters 
        </label>
    </span>
</p>
```

After:
```
<p class="ctct-form-field">
    <span class="ctct-label-top">
        <label for="custom_text_area___99a6a1bc9800303822f0b441fd116a95_0">
            Custom Text Area
        </label>
    </span>
    <textarea class="ctct-textarea ctct-label-top" name="custom_text_area___99a6a1bc9800303822f0b441fd116a95"
              id="custom_text_area___99a6a1bc9800303822f0b441fd116a95_0" placeholder="" maxlength="500">
    </textarea>
    <span class="ctct-textarea-warning-label">
        Limit 500 Characters
    </span>
</p>
```
