### PR TITLE
Feature/node14 npm7

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/fermium

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "constant-contact-forms",
       "version": "1.11.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
@@ -37,8 +38,8 @@
         "webpack-stream": "^5.2.1"
       },
       "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
+        "node": ">=14",
+        "npm": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "gulpfile.js",
   "engines": {
-    "node": ">=10.0.0",
-    "npm": ">=6.0.0"
+    "node": ">=14",
+    "npm": ">=7"
   },
   "scripts": {
     "build": "NODE_ENV=production gulp",


### PR DESCRIPTION
To ensure we all stay on the same page regarding Node and NPM versions to use for frontend packages and build processes...

* Set engines to Node 14 and NPM 7
* Add .nvmrc file specifying lts/fermium (Node 14.x)
