### PR TITLE
CC-266 Prevent "CTCT has experienced issues" notifications for "503 Service Not Available" errors.

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -132,14 +132,14 @@ class ConstantContact_API {
 				$errors       = $ex->getErrors();
 				$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 				$this->log_errors( $our_errors );
-				constant_contact_set_has_exceptions();
+				constant_contact_forms_maybe_set_exception_notice( $ex );
 			} catch ( Exception $ex ) {
 				$error                = new stdClass();
 				$error->error_key     = get_class( $ex );
 				$error->error_message = $ex->getMessage();
 
 				add_filter( 'constant_contact_force_logging', '__return_true' );
-				constant_contact_set_has_exceptions();
+				constant_contact_forms_maybe_set_exception_notice( $ex );
 
 				$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
 				$our_errors[] = $extra . ' - ' . $error->error_key . ' - ' . $error->error_message;
@@ -177,14 +177,14 @@ class ConstantContact_API {
 				$errors       = $ex->getErrors();
 				$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 				$this->log_errors( $our_errors );
-				constant_contact_set_has_exceptions();
+				constant_contact_forms_maybe_set_exception_notice( $ex );
 			} catch ( Exception $ex ) {
 				$error                = new stdClass();
 				$error->error_key     = get_class( $ex );
 				$error->error_message = $ex->getMessage();
 
 				add_filter( 'constant_contact_force_logging', '__return_true' );
-				constant_contact_set_has_exceptions();
+				constant_contact_forms_maybe_set_exception_notice( $ex );
 
 				$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
 				$our_errors[] = $extra . ' - ' . $error->error_key . ' - ' . $error->error_message;
@@ -230,14 +230,14 @@ class ConstantContact_API {
 				$errors       = $ex->getErrors();
 				$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 				$this->log_errors( $our_errors );
-				constant_contact_set_has_exceptions();
+				constant_contact_forms_maybe_set_exception_notice( $ex );
 			} catch ( Exception $ex ) {
 				$error                = new stdClass();
 				$error->error_key     = get_class( $ex );
 				$error->error_message = $ex->getMessage();
 
 				add_filter( 'constant_contact_force_logging', '__return_true' );
-				constant_contact_set_has_exceptions();
+				constant_contact_forms_maybe_set_exception_notice( $ex );
 
 				$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
 				$our_errors[] = $extra . ' - ' . $error->error_key . ' - ' . $error->error_message;
@@ -281,14 +281,14 @@ class ConstantContact_API {
 				$errors       = $ex->getErrors();
 				$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 				$this->log_errors( $our_errors );
-				constant_contact_set_has_exceptions();
+				constant_contact_forms_maybe_set_exception_notice( $ex );
 			} catch ( Exception $ex ) {
 				$error                = new stdClass();
 				$error->error_key     = get_class( $ex );
 				$error->error_message = $ex->getMessage();
 
 				add_filter( 'constant_contact_force_logging', '__return_true' );
-				constant_contact_set_has_exceptions();
+				constant_contact_forms_maybe_set_exception_notice( $ex );
 
 				$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
 				$our_errors[] = $extra . ' - ' . $error->error_key . ' - ' . $error->error_message;
@@ -324,14 +324,14 @@ class ConstantContact_API {
 			$errors       = $ex->getErrors();
 			$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 			$this->log_errors( $our_errors );
-			constant_contact_set_has_exceptions();
+			constant_contact_forms_maybe_set_exception_notice( $ex );
 		} catch ( Exception $ex ) {
 			$error                = new stdClass();
 			$error->error_key     = get_class( $ex );
 			$error->error_message = $ex->getMessage();
 
 			add_filter( 'constant_contact_force_logging', '__return_true' );
-			constant_contact_set_has_exceptions();
+			constant_contact_forms_maybe_set_exception_notice( $ex );
 
 			$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
 			$our_errors[] = $extra . ' - ' . $error->error_key . ' - ' . $error->error_message;
@@ -365,14 +365,14 @@ class ConstantContact_API {
 			$errors       = $ex->getErrors();
 			$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 			$this->log_errors( $our_errors );
-			constant_contact_set_has_exceptions();
+			constant_contact_forms_maybe_set_exception_notice( $ex );
 		} catch ( Exception $ex ) {
 			$error                = new stdClass();
 			$error->error_key     = get_class( $ex );
 			$error->error_message = $ex->getMessage();
 
 			add_filter( 'constant_contact_force_logging', '__return_true' );
-			constant_contact_set_has_exceptions();
+			constant_contact_forms_maybe_set_exception_notice( $ex );
 
 			$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
 			$our_errors[] = $extra . ' - ' . $error->error_key . ' - ' . $error->error_message;
@@ -418,14 +418,14 @@ class ConstantContact_API {
 			$errors       = $ex->getErrors();
 			$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 			$this->log_errors( $our_errors );
-			constant_contact_set_has_exceptions();
+			constant_contact_forms_maybe_set_exception_notice( $ex );
 		} catch ( Exception $ex ) {
 			$error                = new stdClass();
 			$error->error_key     = get_class( $ex );
 			$error->error_message = $ex->getMessage();
 
 			add_filter( 'constant_contact_force_logging', '__return_true' );
-			constant_contact_set_has_exceptions();
+			constant_contact_forms_maybe_set_exception_notice( $ex );
 
 			$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
 			$our_errors[] = $extra . ' - ' . $error->error_key . ' - ' . $error->error_message;
@@ -459,14 +459,14 @@ class ConstantContact_API {
 			$errors       = $ex->getErrors();
 			$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 			$this->log_errors( $our_errors );
-			constant_contact_set_has_exceptions();
+			constant_contact_forms_maybe_set_exception_notice( $ex );
 		} catch ( Exception $ex ) {
 			$error                = new stdClass();
 			$error->error_key     = get_class( $ex );
 			$error->error_message = $ex->getMessage();
 
 			add_filter( 'constant_contact_force_logging', '__return_true' );
-			constant_contact_set_has_exceptions();
+			constant_contact_forms_maybe_set_exception_notice( $ex );
 
 			$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
 			$our_errors[] = $extra . ' - ' . $error->error_key . ' - ' . $error->error_message;
@@ -528,18 +528,14 @@ class ConstantContact_API {
 			$errors       = $ex->getErrors();
 			$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 			$this->log_errors( $our_errors );
-			if ( 400 !== $ex->getCode() || false !== strpos( $ex->getMessage(), 'Bad request' ) ) {
-				constant_contact_set_has_exceptions();
-			}
+			constant_contact_forms_maybe_set_exception_notice( $ex );
 		} catch ( Exception $ex ) {
 			$error                = new stdClass();
 			$error->error_key     = get_class( $ex );
 			$error->error_message = $ex->getMessage();
 
 			add_filter( 'constant_contact_force_logging', '__return_true' );
-			if ( 400 !== $ex->getCode() || false !== strpos( $ex->getMessage(), 'Bad request' ) ) {
-				constant_contact_set_has_exceptions();
-			}
+			constant_contact_forms_maybe_set_exception_notice( $ex );
 
 			$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
 			$our_errors[] = $extra . ' - ' . $error->error_key . ' - ' . $error->error_message;
@@ -602,14 +598,14 @@ class ConstantContact_API {
 			$errors       = $ex->getErrors();
 			$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 			$this->log_errors( $our_errors );
-			constant_contact_set_has_exceptions();
+			constant_contact_forms_maybe_set_exception_notice( $ex );
 		} catch ( Exception $ex ) {
 			$error                = new stdClass();
 			$error->error_key     = get_class( $ex );
 			$error->error_message = $ex->getMessage();
 
 			add_filter( 'constant_contact_force_logging', '__return_true' );
-			constant_contact_set_has_exceptions();
+			constant_contact_forms_maybe_set_exception_notice( $ex );
 
 			$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
 			$our_errors[] = $extra . ' - ' . $error->error_key . ' - ' . $error->error_message;
@@ -617,7 +613,7 @@ class ConstantContact_API {
 		}
 
 		/*
-		 * See: http://developer.constantcontact.com/docs/contacts-api/contacts-index.html#opt_in
+		 * See: http://v2.developer.constantcontact.com/docs/contacts-api/contacts-index.html#opt_in
 		 */
 		return $this->cc()->contactService->addContact(
 			$api_token,
@@ -661,14 +657,14 @@ class ConstantContact_API {
 				$errors       = $ex->getErrors();
 				$our_errors[] = $extra . ' - ' . $errors[0]->error_key . ' - ' . $errors[0]->error_message;
 				$this->log_errors( $our_errors );
-				constant_contact_set_has_exceptions();
+				constant_contact_forms_maybe_set_exception_notice( $ex );
 			} catch ( Exception $ex ) {
 				$error                = new stdClass();
 				$error->error_key     = get_class( $ex );
 				$error->error_message = $ex->getMessage();
 
 				add_filter( 'constant_contact_force_logging', '__return_true' );
-				constant_contact_set_has_exceptions();
+				constant_contact_forms_maybe_set_exception_notice( $ex );
 
 				$extra        = constant_contact_location_and_line( __METHOD__, __LINE__ );
 				$our_errors[] = $extra . ' - ' . $error->error_key . ' - ' . $error->error_message;
@@ -676,7 +672,7 @@ class ConstantContact_API {
 			}
 
 			/*
-			 * See: http://developer.constantcontact.com/docs/contacts-api/contacts-index.html#opt_in array( 'action_by' => 'ACTION_BY_VISITOR' )
+			 * See: http://v2.developer.constantcontact.com/docs/contacts-api/contacts-index.html#opt_in array( 'action_by' => 'ACTION_BY_VISITOR' )
 			 */
 			return $this->cc()->contactService->updateContact(
 				$api_token,
@@ -827,7 +823,7 @@ class ConstantContact_API {
 						$extra    = constant_contact_location_and_line( __METHOD__, __LINE__ );
 						$errors[] = $extra . $e->getErrors();
 						$this->log_errors( $errors );
-						constant_contact_set_has_exceptions();
+						constant_contact_forms_maybe_set_exception_notice( $e );
 						break;
 					}
 

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -832,3 +832,31 @@ add_action( 'untrashed_post', 'constant_contact_remove_form_references_on_restor
 function constant_contact_maybe_display_deleted_forms_notice() {
 	return ! empty( get_option( ConstantContact_Notifications::$deleted_forms, [] ) );
 }
+
+/**
+ * Maybe set exception notice for admin notification.
+ *
+ * @since NEXT
+ *
+ * @param Exception $e
+ */
+function constant_contact_forms_maybe_set_exception_notice( $e ) {
+
+	// Do not notify if the exception code is 400 or the message contains "Bad Request".
+	if (
+		( 400 === $e->getCode() ) ||
+		( false !== stripos( $e->getMessage(), 'Bad Request' ) )
+	) {
+		return;
+	}
+
+	// Do not notify if the exception code is 503 or the message contains "Service Unavailable".
+	if (
+		( 503 === $e->getCode() ) ||
+		( false !== stripos( $e->getMessage(), 'Service Unavailable' ) )
+	) {
+		return;
+	}
+
+	constant_contact_set_has_exceptions();
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,20 @@
 <phpunit
-	bootstrap="tests/bootstrap.php"
-	backupGlobals="false"
-	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
-	>
-	<testsuites>
-		<testsuite>
-			<directory prefix="test-" suffix=".php">./tests/</directory>
-		</testsuite>
-	</testsuites>
+        bootstrap="tests/bootstrap.php"
+        backupGlobals="false"
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+>
+
+    <testsuites>
+
+        <testsuite name="integration">
+            <directory prefix="test-" suffix=".php" phpVersion="5.6.0" phpVersionOperator=">=">
+                ./tests/
+            </directory>
+        </testsuite>
+
+    </testsuites>
+
 </phpunit>

--- a/tests/test-helper-functions.php
+++ b/tests/test-helper-functions.php
@@ -33,4 +33,40 @@ class ConstantContact_Helper_Functions_Test extends WP_UnitTestCase {
 		delete_option( self::EXCEPT_OPTION_NAME );
 		parent::tearDown();
 	}
+
+	/**
+	 * Test that constant_contact_set_has_exceptions( 'false' )
+	 * sets the ctct_exceptions_exist option to 'false'.
+	 *
+	 * @since NEXT
+	 *
+	 * @test
+	 */
+	public function test_constant_contact_set_has_exceptions_false() {
+
+		constant_contact_set_has_exceptions( 'false' );
+
+		$this->assertEquals(
+			get_option( self::EXCEPT_OPTION_NAME ),
+			'false'
+		);
+	}
+
+	/**
+	 * Test that constant_contact_set_has_exceptions( 'true' )
+	 * sets the ctct_exceptions_exist option to 'true'.
+	 *
+	 * @since NEXT
+	 *
+	 * @test
+	 */
+	public function test_constant_contact_set_has_exceptions_true() {
+
+		constant_contact_set_has_exceptions( 'true' );
+
+		$this->assertEquals(
+			get_option( self::EXCEPT_OPTION_NAME ),
+			'true'
+		);
+	}
 }

--- a/tests/test-helper-functions.php
+++ b/tests/test-helper-functions.php
@@ -69,4 +69,77 @@ class ConstantContact_Helper_Functions_Test extends WP_UnitTestCase {
 			'true'
 		);
 	}
+
+	/**
+	 * Test that an Exception with a 418 code
+	 * sets ctct_exceptions_exist option to 'true'.
+	 *
+	 * @since NEXT
+	 *
+	 * @test
+	 */
+	public function test_exception_with_418_error_sets_ctct_exceptions_exist_to_true() {
+
+		/**
+		 * Note that 418 was chosen simply because
+		 * it was not implemented in guzzlehttp/guzzle:^5.1.0.
+		 */
+		constant_contact_forms_maybe_set_exception_notice(
+			new Exception(
+				'I\'m a teapot',
+				418
+			)
+		);
+
+		$this->assertEquals(
+			get_option( self::EXCEPT_OPTION_NAME ),
+			'true'
+		);
+	}
+
+	/**
+	 * Test that an Exception with a 400 code
+	 * does not set ctct_exceptions_exist option to 'true'.
+	 *
+	 * @since NEXT
+	 *
+	 * @test
+	 */
+	public function test_exception_with_400_error_does_not_set_ctct_exceptions_exist_to_true() {
+
+		constant_contact_forms_maybe_set_exception_notice(
+			new Exception(
+				'Bad Request',
+				400
+			)
+		);
+
+		$this->assertNotEquals(
+			get_option( self::EXCEPT_OPTION_NAME ),
+			'true'
+		);
+	}
+
+	/**
+	 * Test that an Exception with a 503 code
+	 * does not set ctct_exceptions_exist option to 'true'.
+	 *
+	 * @since NEXT
+	 *
+	 * @test
+	 */
+	public function test_exception_with_503_error_does_not_set_ctct_exceptions_exist_to_true() {
+
+		constant_contact_forms_maybe_set_exception_notice(
+			new Exception(
+				'Service Unavailable',
+				503
+			)
+		);
+
+		$this->assertNotEquals(
+			get_option( self::EXCEPT_OPTION_NAME ),
+			'true'
+		);
+	}
 }

--- a/tests/test-helper-functions.php
+++ b/tests/test-helper-functions.php
@@ -9,6 +9,11 @@
 class ConstantContact_Helper_Functions_Test extends WP_UnitTestCase {
 
 	/**
+	 * The option name used by constant_contact_set_has_exceptions().
+	 */
+	const EXCEPT_OPTION_NAME = 'ctct_exceptions_exist';
+
+	/**
 	 * Runs the routine before each test is executed.
 	 *
 	 * @since NEXT
@@ -25,6 +30,7 @@ class ConstantContact_Helper_Functions_Test extends WP_UnitTestCase {
 	 */
 	public function tearDown() {
 		// This code will run after each test.
+		delete_option( self::EXCEPT_OPTION_NAME );
 		parent::tearDown();
 	}
 }

--- a/tests/test-helper-functions.php
+++ b/tests/test-helper-functions.php
@@ -8,9 +8,4 @@
 
 class ConstantContact_Helper_Functions_Test extends WP_UnitTestCase {
 
-	function test_functions_exist() {
-		$this->assertTrue( function_exists( 'constant_contact_get_form' ) );
-		$this->assertTrue( function_exists( 'constant_contact_display_form' ) );
-		$this->assertTrue( function_exists( 'constant_contact_get_forms' ) );
-	}
 }

--- a/tests/test-helper-functions.php
+++ b/tests/test-helper-functions.php
@@ -13,9 +13,4 @@ class ConstantContact_Helper_Functions_Test extends WP_UnitTestCase {
 		$this->assertTrue( function_exists( 'constant_contact_display_form' ) );
 		$this->assertTrue( function_exists( 'constant_contact_get_forms' ) );
 	}
-
-	function test_sample() {
-		// replace this with some actual testing code
-		$this->assertTrue( true );
-	}
 }

--- a/tests/test-helper-functions.php
+++ b/tests/test-helper-functions.php
@@ -8,4 +8,23 @@
 
 class ConstantContact_Helper_Functions_Test extends WP_UnitTestCase {
 
+	/**
+	 * Runs the routine before each test is executed.
+	 *
+	 * @since NEXT
+	 */
+	public function setUp() {
+		// This code will run before each test.
+		parent::setUp();
+	}
+
+	/**
+	 * After a test method runs, resets any state in WordPress the test method might have changed.
+	 *
+	 * @since NEXT
+	 */
+	public function tearDown() {
+		// This code will run after each test.
+		parent::tearDown();
+	}
 }


### PR DESCRIPTION
CC-266

There were multiple places in the `ConstantContact_API` class that could potentially call `constant_contact_set_has_exceptions()` from `try/catch` blocks.

In two places there was `if/else` logic wrapped around those calls to prevent an `Exception` with an error code of `400` from triggering the "CTCT has experienced issues" admin notice, like so
```php
if ( 400 !== $ex->getCode() || false !== strpos( $ex->getMessage(), 'Bad request' ) ) {
    constant_contact_set_has_exceptions();
}
```

For this ticket we intended to introduce another bit of logic to exclude `Exception`s with `503` errors, and it felt like that would make the `ConstantContact_API` class code harder to read, understand, and maintain by introducing more `if/else` logic into the `try/catch` blocks.

It seemed to make sense to introduce a new utility method or helper function that can wrap the calls to `constant_contact_set_has_exceptions()`, where we can do some work to determine if we want to trigger the notice or not, rather than introducing additional `if/else` blocks directly into the `ConstantContact_API` class. If we get an `Exception` in a `try/catch`, just pass the `Exception` into the new utility method or helper function, and do any necessary logic in there.

Since triggering these errors from the API directly would be nigh-impossible, I added some tests to `ConstantContact_Helper_Functions_Test` to ensure that `Exception`s with `400` and `503`  error codes would not trigger the admin notices, but a `418` `I'm a Teapot` `Exception` would _(side note, I removed some absolutely useless sample tests from `ConstantContact_Helper_Functions_Test` while I was at it). 

```
bash-3.2$ pwd
~/Local Sites/constantcontact/app/public/wp-content/plugins/constant-contact-forms
bash-3.2$ ./vendor/phpunit/phpunit/phpunit --verbose
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 7.5.16 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.5 with Xdebug 2.9.0
Configuration: ~/Local Sites/constantcontact/app/public/wp-content/plugins/constant-contact-forms/phpunit.xml.dist

................................................................. 65 / 66 ( 98%)
.                                                                 66 / 66 (100%)

Time: 1.73 seconds, Memory: 10.00 MB

OK (66 tests, 90 assertions)
```