### PR TITLE
Initial universal code sign-up.

### DIFF
--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -339,12 +339,12 @@ class Constant_Contact {
 	private $beaver_builder;
 
 	/**
-	 * An instance of the ConstantContact_Signup_Forms class.
+	 * An instance of the ConstantContact_Inline_Forms class.
 	 *
 	 * @since NEXT
-	 * @var ConstantContact_Signup_Forms
+	 * @var ConstantContact_Inline_Forms
 	 */
-	private $signup_forms;
+	private $inline_forms;
 
 	/*
 	 * An instance of the ConstantContact_Elementor class.
@@ -445,7 +445,7 @@ class Constant_Contact {
 			// Load if Beaver Builder is active.
 			$this->beaver_builder       = new ConstantContact_Beaver_Builder( $this );
 		}
-		$this->signup_forms         = new ConstantContact_Signup_Forms( $this );
+		$this->inline_forms         = new ConstantContact_Inline_Forms( $this );
 		$this->builder              = new ConstantContact_Builder( $this );
 		$this->builder_fields       = new ConstantContact_Builder_Fields( $this );
 		$this->check                = new ConstantContact_Check( $this );

--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -839,7 +839,7 @@ class Constant_Contact {
 			return false;
 		}
 
-		$ctct_types = [ 'ctct_forms', 'ctct_lists' ];
+		$ctct_types = [ 'ctct_forms', 'ctct_lists', 'ctct_inline_forms' ];
 		$post_type  = filter_input( INPUT_GET, 'post_type', FILTER_SANITIZE_STRING );
 		$post       = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
 

--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -338,6 +338,14 @@ class Constant_Contact {
 	 */
 	private $beaver_builder;
 
+	/**
+	 * An instance of the ConstantContact_Signup_Forms class.
+	 *
+	 * @since NEXT
+	 * @var ConstantContact_Signup_Forms
+	 */
+	private $signup_forms;
+
 	/*
 	 * An instance of the ConstantContact_Elementor class.
 	 *
@@ -437,6 +445,7 @@ class Constant_Contact {
 			// Load if Beaver Builder is active.
 			$this->beaver_builder       = new ConstantContact_Beaver_Builder( $this );
 		}
+		$this->signup_forms         = new ConstantContact_Signup_Forms( $this );
 		$this->builder              = new ConstantContact_Builder( $this );
 		$this->builder_fields       = new ConstantContact_Builder_Fields( $this );
 		$this->check                = new ConstantContact_Check( $this );

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -119,8 +119,6 @@ class ConstantContact_Admin {
 	 */
 	public function current_screen( $screen ) {
 
-		$post_type_array = [ 'ctct_forms', 'ctct_lists' ];	
-
 		// Determine if the current page being viewed is Constant Contact.
 		if ( constant_contact()->is_constant_contact() ) {
 			add_action( 'in_admin_header', [ $this, 'admin_page_toolbar' ] );

--- a/includes/class-builder-fields.php
+++ b/includes/class-builder-fields.php
@@ -307,7 +307,6 @@ class ConstantContact_Builder_Fields {
 			'id'              => $this->prefix . 'redirect_uri',
 			'type'            => 'text',
 			'description'     => sprintf(
-				/* Translators: 1: basic field info, 2: warning about invalid values, 3: recommended field value */
 				'%1$s</br><strong>%2$s</strong><br/>%3$s',
 				esc_html__( 'Leave blank to keep users on the current page.', 'constant-contact-forms' ),
 				esc_html__( 'NOTE: This URL must be within the current site and may not be a direct link to a media file (e.g., a PDF document). Providing a Redirect URL that is outside the current site or is a media file will cause issues with Constant Constact functionality, including contacts not being added to lists successfully.', 'constant-contact-forms' ),

--- a/includes/class-cpts.php
+++ b/includes/class-cpts.php
@@ -46,6 +46,7 @@ class ConstantContact_CPTS {
 	public function hooks() {
 		add_action( 'init', [ $this, 'forms_post_type' ] );
 		add_action( 'init', [ $this, 'lists_post_type' ] );
+		add_action( 'init', [ $this, 'signup_post_type' ] );
 
 		add_filter( 'post_updated_messages', [ $this, 'post_updated_messages' ] );
 		add_filter( 'enter_title_here', [ $this, 'change_default_title' ] );
@@ -168,6 +169,64 @@ class ConstantContact_CPTS {
 		if ( constantcontact_api()->is_connected() ) {
 			register_post_type( 'ctct_lists', $args );
 		}
+	}
+
+	/**
+	 * Register Custom Post Type.
+	 *
+	 * @since 1.0.0
+	 */
+	public function signup_post_type() {
+
+		$labels = [
+			'name'                  => _x( 'Inline Forms', 'Post Type General Name', 'constant-contact-forms' ),
+			'singular_name'         => _x( 'Inline Form', 'Post Type Singular Name', 'constant-contact-forms' ),
+			'menu_name'             => __( 'Inline Forms', 'constant-contact-forms' ),
+			'name_admin_bar'        => __( 'Inline Forms', 'constant-contact-forms' ),
+			'archives'              => __( 'Inline Form Archives', 'constant-contact-forms' ),
+			'parent_item_colon'     => __( 'Parent Inline Form:', 'constant-contact-forms' ),
+			'all_items'             => __( 'Inline Forms', 'constant-contact-forms' ),
+			'add_new_item'          => __( 'Add New Inline Form', 'constant-contact-forms' ),
+			'add_new'               => __( 'Add New Inline Form', 'constant-contact-forms' ),
+			'new_item'              => __( 'New Inline Form', 'constant-contact-forms' ),
+			'edit_item'             => __( 'Edit Inline Form', 'constant-contact-forms' ),
+			'update_item'           => __( 'Update Inline Form', 'constant-contact-forms' ),
+			'view_item'             => __( 'View Inline Form', 'constant-contact-forms' ),
+			'search_items'          => __( 'Search Inline Form', 'constant-contact-forms' ),
+			'not_found'             => __( 'Not found', 'constant-contact-forms' ),
+			'not_found_in_trash'    => __( 'Not found in Trash', 'constant-contact-forms' ),
+			'featured_image'        => __( 'Featured Image', 'constant-contact-forms' ),
+			'set_featured_image'    => __( 'Set featured image', 'constant-contact-forms' ),
+			'remove_featured_image' => __( 'Remove featured image', 'constant-contact-forms' ),
+			'use_featured_image'    => __( 'Use as featured image', 'constant-contact-forms' ),
+			'insert_into_item'      => __( 'Insert into Inline Form', 'constant-contact-forms' ),
+			'uploaded_to_this_item' => __( 'Uploaded to this Inline Form', 'constant-contact-forms' ),
+			'items_inline_form'            => __( 'Inline Forms list', 'constant-contact-forms' ),
+			'items_inline_form_navigation' => __( 'Inline Forms list navigation', 'constant-contact-forms' ),
+			'filter_items_list'     => __( 'Filter Inline forms list', 'constant-contact-forms' ),
+		];
+		$args   = [
+			'label'               => __( 'Constant Contact', 'constant-contact-forms' ),
+			'description'         => __( 'Constant Contact inline forms.', 'constant-contact-forms' ),
+			'labels'              => $labels,
+			'supports'            => [ 'title' ],
+			'taxonomies'          => [],
+			'hierarchical'        => false,
+			'public'              => false,
+			'show_ui'             => true,
+			'show_in_menu'        => 'edit.php?post_type=ctct_forms',
+			'menu_position'       => 20,
+			'menu_icon'           => 'dashicons-megaphone',
+			'show_in_admin_bar'   => false,
+			'show_in_nav_menus'   => false,
+			'can_export'          => true,
+			'has_archive'         => false,
+			'exclude_from_search' => true,
+			'publicly_queryable'  => false,
+			'capability_type'     => 'page',
+		];
+
+		register_post_type( 'ctct_inline_forms', $args );
 	}
 
 	/**

--- a/includes/class-inline-forms.php
+++ b/includes/class-inline-forms.php
@@ -3,7 +3,7 @@
  * Sign-up Forms
  *
  * @package ConstantContact
- * @subpackage Beaver Builder
+ * @subpackage Inline Forms
  * @author Constant Contact
  * @since NEXT
  *
@@ -11,7 +11,7 @@
  */
 
 /**
- * This class get's everything up an running for Sign-up Forms.
+ * This class get's everything up an running for Inline Forms.
  *
  * @since NEXT
  */
@@ -42,10 +42,10 @@ class ConstantContact_Inline_Forms {
 	 */
 	public function __construct( $plugin ) {
 		$this->plugin = $plugin;
-        $this->hooks();
+		$this->hooks();
 	}
 
-    /**
+	/**
 	 * Initiate our hooks.
 	 *
 	 * @since 1.0.0
@@ -59,7 +59,7 @@ class ConstantContact_Inline_Forms {
 		add_action( 'manage_ctct_inline_forms_posts_custom_column', [ $this, 'custom_columns' ], 10, 2 );
 	}
 
-    /**
+	/**
 	 * Attempt to inject Universal Code of All Sign-up Forms.
 	 *
 	 * @author Scott Anderson <scott.anderson@webdevstudios.com>
@@ -67,15 +67,15 @@ class ConstantContact_Inline_Forms {
 	 *
 	 * @return void
 	 */
-    public function inject_universal_code() : void {
-        $universal_code         = constant_contact_get_option( '_ctct_signup_universal_code', '' );
+	public function inject_universal_code() : void {
+		$universal_code         = constant_contact_get_option( '_ctct_signup_universal_code', '' );
 		$disable_universal_code = constant_contact_get_option( '_ctct_signup_uc_disable', 'off' );
 
-        if ( '' === $universal_code || 'on' === $disable_universal_code ) {
-            return;
-        }
-        echo $universal_code;
-    }
+		if ( '' === $universal_code || 'on' === $disable_universal_code ) {
+			return;
+		}
+		echo $universal_code;
+	}
 
 	/**
 	 * Register Metaboxes for Inline Forms.
@@ -110,16 +110,19 @@ class ConstantContact_Inline_Forms {
 	 */
 	public function render_inline_form( $args ) {
 
-		$post_id = absint( $args['form'] );
+		if ( ! array_key_exists( 'form', $args ) ) {
+			return;
+		}
+
+		$post_id = absint( sanitize_text_field( $args['form'] ) );
 
 		$inline_code = get_post_meta( $post_id, 'ctct_inline_code', true );
-		if ( '' === $inline_code ) {
-            return;
-        }
 
-		ob_start();
-		echo $inline_code;
-		return ob_get_clean();
+		if ( '' === $inline_code ) {
+			return;
+		}
+
+		return $inline_code;
 	}
 
 	/**
@@ -152,7 +155,7 @@ class ConstantContact_Inline_Forms {
 				'</em>',
 				'</small>'
 			),
-			'default'    => ( $generated->object_id > 0 ) ? '[ctct-inline-form id="' . $generated->object_id . '"]' : '',
+			'default'    => ( $generated->object_id > 0 ) ? '[ctct-inline-form form="' . $generated->object_id . '"]' : '',
 			'attributes' => [
 				'readonly' => 'readonly',
 			],

--- a/includes/class-inline-forms.php
+++ b/includes/class-inline-forms.php
@@ -15,7 +15,7 @@
  *
  * @since NEXT
  */
-class ConstantContact_Signup_Forms {
+class ConstantContact_Inline_Forms {
 
 	/**
 	 * Parent plugin class.
@@ -55,10 +55,12 @@ class ConstantContact_Signup_Forms {
 		add_action( 'cmb2_admin_init', [ $this, 'register_metaboxes' ] );
 		add_action( 'cmb2_admin_init', [ $this, 'generated_shortcode' ] );
 		add_shortcode('ctct-inline-form', [$this, 'render_inline_form']);
+		add_filter( 'manage_ctct_inline_forms_posts_columns', [ $this, 'set_custom_columns' ] );
+		add_action( 'manage_ctct_inline_forms_posts_custom_column', [ $this, 'custom_columns' ], 10, 2 );
 	}
 
     /**
-	 * Attempt to inject Universal Code of Sign-up Form.
+	 * Attempt to inject Universal Code of All Sign-up Forms.
 	 *
 	 * @author Scott Anderson <scott.anderson@webdevstudios.com>
 	 * @since  NEXT
@@ -108,7 +110,7 @@ class ConstantContact_Signup_Forms {
 	 */
 	public function render_inline_form( $args ) {
 
-		$post_id = absint( $args['id'] );
+		$post_id = absint( $args['form'] );
 
 		$inline_code = get_post_meta( $post_id, 'ctct_inline_code', true );
 		if ( '' === $inline_code ) {
@@ -121,7 +123,7 @@ class ConstantContact_Signup_Forms {
 	}
 
 	/**
-	 * Show a metabox rendering inline shortcode.
+	 * Show a metabox rendering inline forms shortcode.
 	 *
 	 * @author Scott Anderson <scott.anderson@webdevstudios.com>
 	 * @since  NEXT
@@ -155,6 +157,61 @@ class ConstantContact_Signup_Forms {
 				'readonly' => 'readonly',
 			],
 		] );
+	}
+
+	/**
+	 * Add columns to Inline Forms post type.
+	 *
+	 * @internal
+	 *
+	 * @since NEXT
+	 *
+	 * @param array $columns post list columns.
+	 * @return array $columns Array of columns to add.
+	 */
+	public function set_custom_columns( $columns ) {
+
+		$columns['shortcodes']  = esc_html__( 'Shortcode', 'constant-contact-forms' );
+
+		return $columns;
+	}
+
+	/**
+	 * Content of custom post columns.
+	 *
+	 * @internal
+	 *
+	 * @since NEXT
+	 *
+	 * @param string  $column  Column title.
+	 * @param integer $post_id Post id of post item.
+	 *
+	 * @return void
+	 */
+	public function custom_columns( $column, $post_id ) {
+		$post_id = absint( $post_id );
+
+		if ( ! $post_id ) {
+			return;
+		}
+
+		$table_list_ids = get_post_meta( $post_id, '_ctct_list', true );
+		$table_list_ids = is_array( $table_list_ids ) ? $table_list_ids : [ $table_list_ids ];
+
+		switch ( $column ) {
+			case 'shortcodes':
+				echo '<div class="ctct-shortcode-wrap"><input class="ctct-shortcode" type="text" value="';
+				echo esc_html( '[ctct-inline-form form="' . $post_id . '"]' );
+				echo '" readonly="readonly">';
+				echo '<button type="button" class="button" data-copied="' . esc_html( 'Copied!', 'constant-contact-forms' ) . '">';
+				echo esc_html__( 'Copy', 'constant-contact-forms' );
+				echo '</button>';
+				echo '</div>';
+				break;
+			case 'description':
+				echo wp_kses_post( wpautop( get_post_meta( $post_id, '_ctct_description', true ) ) );
+				break;
+		}
 	}
 
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -498,6 +498,42 @@ class ConstantContact_Settings {
 			'id'         => '_ctct_alternative_legal_text',
 			'type'       => 'textarea',
 		] );
+
+
+		$before_global_css = sprintf(
+			/* translators: 1: horizontal rule and opening heading tag, 2: signup section H, 3: closing heading tag */
+			'%1$s%2$s%3$s',
+			'<hr><h2>',
+			esc_html__( 'Global Form CSS Settings', 'constant-contact-forms' ),
+			'</h2>'
+		);
+
+		$cmb->add_field( [
+			'name'        => esc_html__( 'CSS Classes', 'constant-contact-forms' ),
+			'id'          => '_ctct_form_custom_classes',
+			'type'        => 'text',
+			'description' => esc_html__(
+					'Provide custom classes for the form separated by a single space.',
+					'constant-contact-forms'
+			),
+			'before_row'  => $before_global_css,
+		] );
+
+		$before_signup_css = sprintf(
+			/* translators: 1: horizontal rule and opening heading tag, 2: signup section H, 3: closing heading tag */
+			'%1$s%2$s%3$s',
+			'<hr><h2>',
+			esc_html__( 'Sign-up Form Settings', 'constant-contact-forms' ),
+			'</h2>'
+		);
+
+		$cmb->add_field( [
+			'name'       => esc_html__( 'Universal Code', 'constant-contact-forms' ),
+			'desc'       => esc_html__( 'Universal Code found in Constant Contact Sign-up Dashboard.', 'constant-contact-forms' ),
+			'id'         => '_ctct_signup_universal_code',
+			'type'       => 'textarea_code',
+			'before_row'  => $before_signup_css,
+		] );
 		
 	}
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -534,6 +534,13 @@ class ConstantContact_Settings {
 			'type'       => 'textarea_code',
 			'before_row'  => $before_signup_css,
 		] );
+
+		$cmb->add_field( [
+			'name'       => esc_html__( 'Disable Universal Code', 'constant-contact-forms' ),
+			'desc'       => esc_html__( 'Temporarily disable Universal Code for debugging.', 'constant-contact-forms' ),
+			'id'         => '_ctct_signup_uc_disable',
+			'type'       => 'checkbox',
+		] );
 		
 	}
 

--- a/includes/class-signup-forms.php
+++ b/includes/class-signup-forms.php
@@ -26,6 +26,14 @@ class ConstantContact_Signup_Forms {
 	protected $plugin;
 
 	/**
+	 * Inline Forms Slug.
+	 *
+	 * @since NEXT
+	 * @var string
+	 */
+	private $slug = 'ctct_inline_forms';
+
+	/**
 	 * Constructor.
 	 *
 	 * @since NEXT
@@ -45,7 +53,8 @@ class ConstantContact_Signup_Forms {
 	public function hooks() {
 		add_action( 'wp_head', [ $this, 'inject_universal_code' ] );
 		add_action( 'cmb2_admin_init', [ $this, 'register_metaboxes' ] );
-		add_shortcode('ctct-line-form', [$this, 'render_inline_form']);
+		add_action( 'cmb2_admin_init', [ $this, 'generated_shortcode' ] );
+		add_shortcode('ctct-inline-form', [$this, 'render_inline_form']);
 	}
 
     /**
@@ -95,7 +104,7 @@ class ConstantContact_Signup_Forms {
 	 * @since  NEXT
 	 * @param  array $args Shortcode Args
 	 *
-	 * @return array
+	 * @return string
 	 */
 	public function render_inline_form( $args ) {
 
@@ -105,7 +114,47 @@ class ConstantContact_Signup_Forms {
 		if ( '' === $inline_code ) {
             return;
         }
-        echo $inline_code;
+
+		ob_start();
+		echo $inline_code;
+		return ob_get_clean();
+	}
+
+	/**
+	 * Show a metabox rendering inline shortcode.
+	 *
+	 * @author Scott Anderson <scott.anderson@webdevstudios.com>
+	 * @since  NEXT
+	 *
+	 * @return void
+	 */
+	public function generated_shortcode() {
+		$generated = new_cmb2_box( [
+			'id'           => 'ctct_inline_generated_metabox',
+			'title'        => esc_html__( 'Shortcode', 'constant-contact-forms' ),
+			'object_types' => [ $this->slug ],
+			'context'      => 'side',
+			'priority'     => 'low',
+			'show_names'   => true,
+		] );
+
+		$generated->add_field( [
+			'name'       => esc_html__( 'Shortcode to use', 'constant-contact-forms' ),
+			'id'         => 'ctct_' . 'generated_shortcode',
+			'type'       => 'text_medium',
+			'desc'       => sprintf(
+				/* Translators: Placeholders here represent `<em>` and `<strong>` HTML tags. */
+				esc_html__( 'Shortcode to embed — %1$s%2$sYou can copy and paste this in a post to display your form.%3$s%4$s', 'constant-contact-forms' ),
+				'<small>',
+				'<em>',
+				'</em>',
+				'</small>'
+			),
+			'default'    => ( $generated->object_id > 0 ) ? '[ctct-inline-form id="' . $generated->object_id . '"]' : '',
+			'attributes' => [
+				'readonly' => 'readonly',
+			],
+		] );
 	}
 
 }

--- a/includes/class-signup-forms.php
+++ b/includes/class-signup-forms.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Sign-up Forms
+ *
+ * @package ConstantContact
+ * @subpackage Beaver Builder
+ * @author Constant Contact
+ * @since NEXT
+ *
+ * phpcs:disable WebDevStudios.All.RequireAuthor -- Don't require author tag in docblocks.
+ */
+
+/**
+ * This class get's everything up an running for Sign-up Forms.
+ *
+ * @since NEXT
+ */
+class ConstantContact_Signup_Forms {
+
+	/**
+	 * Parent plugin class.
+	 *
+	 * @since NEXT
+	 * @var object
+	 */
+	protected $plugin;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since NEXT
+	 *
+	 * @param object $plugin Parent plugin.
+	 */
+	public function __construct( $plugin ) {
+		$this->plugin = $plugin;
+        $this->hooks();
+	}
+
+    /**
+	 * Initiate our hooks.
+	 *
+	 * @since 1.0.0
+	 */
+	public function hooks() {
+		add_action( 'wp_head', [ $this, 'inject_universal_code' ] );
+	}
+
+    /**
+	 * Attempt to inject Universal Code of Sign-up Form.
+	 *
+	 * @author Scott Anderson <scott.anderson@webdevstudios.com>
+	 * @since  NEXT
+	 *
+	 * @return void
+	 */
+    public function inject_universal_code() : void {
+        $universal_code = constant_contact_get_option( '_ctct_signup_universal_code', '' );
+        
+        if ( '' === $universal_code ) {
+            return;
+        }
+        echo $universal_code;
+    }
+
+}

--- a/includes/class-signup-forms.php
+++ b/includes/class-signup-forms.php
@@ -44,6 +44,8 @@ class ConstantContact_Signup_Forms {
 	 */
 	public function hooks() {
 		add_action( 'wp_head', [ $this, 'inject_universal_code' ] );
+		add_action( 'cmb2_admin_init', [ $this, 'register_metaboxes' ] );
+		add_shortcode('ctct-line-form', [$this, 'render_inline_form']);
 	}
 
     /**
@@ -63,5 +65,47 @@ class ConstantContact_Signup_Forms {
         }
         echo $universal_code;
     }
+
+	/**
+	 * Register Metaboxes for Inline Forms.
+	 *
+	 * @author Scott Anderson <scott.anderson@webdevstudios.com>
+	 * @since  NEXT
+	 *
+	 * @return void
+	 */
+	public function register_metaboxes() {
+		$inline_details = new_cmb2_box(array(
+			'id'            => 'ctct_inline_metabox',
+			'title'         => esc_html__('Inline Forms Details', 'constant-contact-forms'),
+			'object_types'  => array('ctct_inline_forms'),
+		));
+
+		$inline_details->add_field(array(
+			'name'       => esc_html__('Date Received', 'constant-contact-forms'),
+			'id'         => 'ctct_inline_code',
+			'type'       => 'textarea_code',
+		));
+	}
+
+	/**
+	 * Render Inline Form.
+	 *
+	 * @author Scott Anderson <scott.anderson@webdevstudios.com>
+	 * @since  NEXT
+	 * @param  array $args Shortcode Args
+	 *
+	 * @return array
+	 */
+	public function render_inline_form( $args ) {
+
+		$post_id = absint( $args['id'] );
+
+		$inline_code = get_post_meta( $post_id, 'ctct_inline_code', true );
+		if ( '' === $inline_code ) {
+            return;
+        }
+        echo $inline_code;
+	}
 
 }

--- a/includes/class-signup-forms.php
+++ b/includes/class-signup-forms.php
@@ -55,9 +55,10 @@ class ConstantContact_Signup_Forms {
 	 * @return void
 	 */
     public function inject_universal_code() : void {
-        $universal_code = constant_contact_get_option( '_ctct_signup_universal_code', '' );
-        
-        if ( '' === $universal_code ) {
+        $universal_code         = constant_contact_get_option( '_ctct_signup_universal_code', '' );
+		$disable_universal_code = constant_contact_get_option( '_ctct_signup_uc_disable', 'off' );
+
+        if ( '' === $universal_code || 'on' === $disable_universal_code ) {
             return;
         }
         echo $universal_code;


### PR DESCRIPTION
Ticket: https://webdevstudios.atlassian.net/browse/CC-270

Documentation: https://docs.google.com/document/d/1jZiIoX2BreT1ay5vHOT0exwadpI-z7uM6ynh1iGm2B8/edit?usp=sharing

Description
Added support for pop-ups and inline forms built in the constant contact dashboard.  

1. Provided a way to include the universal code for constant contact.
2. Created new CPT inline form to allow for inline forms to be usable as a shortcode.



