### PR TITLE
CC-283  Have `get_optin_list_options()` options fetch default to empty array

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -498,7 +498,7 @@ class ConstantContact_Settings {
 			'id'         => '_ctct_alternative_legal_text',
 			'type'       => 'textarea',
 		] );
-		
+
 	}
 
 	/**
@@ -1081,7 +1081,7 @@ class ConstantContact_Settings {
 	 * @return array
 	 */
 	private function get_optin_list_options() {
-		$lists = constant_contact_get_option( '_ctct_optin_list', '' );
+		$lists = constant_contact_get_option( '_ctct_optin_list', [] );
 
 		$formatted_lists = [];
 		foreach ( $lists as $list_id ) {


### PR DESCRIPTION
Ticket: https://webdevstudios.atlassian.net/jira/software/projects/CC/boards/9?selectedIssue=CC-283

Description
Default `get_optin_list_options()` to an empty array instead of astring