### PR TITLE
Fixed: HTML5 Native validators not working when ajax is enabled.

### DIFF
--- a/assets/js/ctct-plugin-frontend/validation.js
+++ b/assets/js/ctct-plugin-frontend/validation.js
@@ -231,8 +231,11 @@
 		}
 
 		clearTimeout( app.timeout );
-        e.preventDefault();
-		app.timeout = setTimeout( app.submitForm, 500, $form );
+
+		if($form[0].checkValidity()){
+			e.preventDefault();
+			app.timeout = setTimeout( app.submitForm, 500, $form );
+		}
 	};
 
 	/**


### PR DESCRIPTION
When AJAX is enabled on CTCT forms the html5 validation was disabled. 
This was due to the preventDefault necessary to stop the page from refreshing. 