### PR TITLE
Fix/345 list creation fixes

### DIFF
--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -427,7 +427,9 @@ class ConstantContact_Lists {
 
 			add_post_meta( $ctct_list->ID, 'ctct_duplicate_list', true );
 
-			if ( 'draft' !== $ctct_list->post_status ) {
+			if ( 'trash' === $ctct_list->post_status ) {
+				$return = wp_delete_post( $ctct_list->ID );
+			} else if ( 'draft' !== $ctct_list->post_status ) {
 				$return = wp_update_post(
 					[
 						'ID'          => absint( $ctct_list->ID ),

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -469,10 +469,6 @@ class ConstantContact_Lists {
 			return false;
 		}
 
-		if ( ! isset( $ctct_list ) || empty( $ctct_list ) ) {
-			return false;
-		}
-
 		if ( ! isset( $ctct_list->ID ) || 0 >= $ctct_list->ID ) {
 			return false;
 		}

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -747,8 +747,8 @@ class ConstantContact_Lists {
 		if ( $lists && is_array( $lists ) ) {
 
 			foreach ( $lists as $list ) {
-				if ( isset( $list->id ) && isset( $list->name ) ) {
-					$get_lists[ esc_attr( $list->id ) ] = esc_attr( $list->name );
+				if ( isset( $list['list_id'] ) && isset( $list['name'] ) ) {
+					$get_lists[ esc_attr( $list['list_id'] ) ] = esc_attr( $list['name'] );
 				}
 			}
 		}

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -761,8 +761,12 @@ class ConstantContact_Lists {
 	 */
 	public function maybe_display_duplicate_list_error() {
 		global $pagenow, $post;
-		if ( $pagenow || ( ! in_array( $pagenow, [ 'post.php' ], true ) ) ) {
+		if ( $pagenow && ( ! in_array( $pagenow, [ 'post.php' ], true ) ) ) {
 			return;
+		}
+
+		if ( is_null( $post ) && isset( $_GET['post'] ) && is_numeric( $_GET['post'] ) ) {
+			$post = get_post( sanitize_text_field( $_GET['post'] ) );
 		}
 
 		if (


### PR DESCRIPTION
Closes CC-345

I merged `feature/cc-api-v3-update` into `fix/345-list-creation-fixes` and tested to make sure that duplicate lists could not be created and that a notice is displayed when attempting to create a list who's name already exists. 

Also verified that an existing list can be renamed and that various fields are still being correctly created (which is being handled by the `feature/cc-api-v3-update`. (basically confirming that nothing broke with this update).

![image](https://user-images.githubusercontent.com/12645132/218545802-d78bb986-e400-4f05-a301-48b83f6eefd6.png)
