### PR TITLE
Fix/cc 346 update forms lists

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -327,32 +327,31 @@ class ConstantContact_API {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param string $old_ids_string List of old (v2 API) list ids.
-	 * @param bool $force_skip_cache Whether or not to skip cache.
-	 * @return array Current connect updated ctct lists.
+	 * @param string $old_ids_string Comma separated list of old (v2 API) list ids.
+	 * @param bool   $force_skip_cache Whether or not to skip cache.
+	 * @return array API v2 to v3 List ID cross references.
 	 */
-	public function get_updated_lists_ids( $old_ids_string, $force_skip_cache = false ) {
+	public function get_v2_list_id_x_refs( $old_ids_string, $force_skip_cache = false ) {
 
 		if ( ! $this->is_connected() ) {
 			return [];
 		}
 
-		$lists = get_transient( 'ctct_updated_lists' );
+		$list_x_refs = get_transient('ctct_list_xrefs');
 
 		if ( $force_skip_cache ) {
-			$lists = false;
+			$list_x_refs = false;
 		}
 
-		if ( false === $lists ) {
+		if ( false === $list_x_refs ) {
 
 			try {
 
-				$lists = $this->cc()->get_updated_lists_ids( $old_ids_string );
-				$lists = $lists['lists'];
+				$list_x_refs = $this->cc()->get_updated_lists_ids( $old_ids_string );
 
-				if ( is_array( $lists ) ) {
-					set_transient( 'ctct_updated_lists', $lists, 1 * HOUR_IN_SECONDS );
-					return $lists;
+				if ( is_array( $list_x_refs ) ) {
+					set_transient('ctct_list_xrefs', $list_x_refs, 1 * HOUR_IN_SECONDS );
+					return $list_x_refs;
 				}
 			} catch ( CtctException $ex ) {
 				add_filter( 'constant_contact_force_logging', '__return_true' );
@@ -375,7 +374,7 @@ class ConstantContact_API {
 			}
 		}
 
-		return $lists;
+		return $list_x_refs;
 	}
 
 	/**

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -292,7 +292,7 @@ class ConstantContact_API {
 			try {
 
 				$lists = $this->cc()->get_lists();
-				$lists = $lists['lists'];
+				$lists = $lists['lists'] ?? [];
 
 				if ( is_array( $lists ) ) {
 					set_transient( 'ctct_lists', $lists, 1 * HOUR_IN_SECONDS );

--- a/includes/class-client.php
+++ b/includes/class-client.php
@@ -88,7 +88,7 @@ class ConstantContact_Client {
 	}
 
 	public function get_updated_lists_ids( $old_ids_string ) {
-		return $this->get( "contact_lists/lists_id_xrefs?sequence_ids={$old_ids_string}", $this->base_args );
+		return $this->get( "contact_lists/list_id_xrefs?sequence_ids={$old_ids_string}", $this->base_args );
 	}
 
 	private function get( string $endpoint, $args = [] ) : array {

--- a/includes/class-client.php
+++ b/includes/class-client.php
@@ -87,6 +87,10 @@ class ConstantContact_Client {
 		return $this->delete( "contact_lists/$list_id", $this->base_args );
 	}
 
+	public function get_updated_lists_ids( $old_ids_string ) {
+		return $this->get( "contact_lists/lists_id_xrefs?sequence_ids={$old_ids_string}", $this->base_args );
+	}
+
 	private function get( string $endpoint, $args = [] ) : array {
 
 		$options = [

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -967,7 +967,10 @@ class ConstantContact_Lists {
 			}
 
 			error_log( '$updated_list_ids ' . var_export( $updated_list_ids, true ) );
-			update_post_meta( get_the_ID(), '_ctct_list', $updated_list_ids );
+			// Update the current form's list IDs.
+			if ( ! empty( $updated_list_ids ) ) {
+				update_post_meta( get_the_ID(), '_ctct_list', $updated_list_ids );
+			}
 		}
 
 		return update_option( 'ctct_api_v2_v3_migrated', true );

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -913,6 +913,7 @@ class ConstantContact_Lists {
 			}
 		}
 
+		error_log( '$lists ' . var_export( $lists, true ) );
 		$new_list_ids = $this->get_new_ids_from_list( $lists );
 
 		error_log( '$new_list_ids ' . var_export( $new_list_ids, true ) );

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -891,6 +891,10 @@ class ConstantContact_Lists {
 	 */
 	public function migrate_v2_v3_form_lists() {
 
+		if ( ! constant_contact()->api->is_connected() ) {
+			return false;
+		}
+
 		$migrated = get_option( 'ctct_api_v2_v3_migrated', false );
 
 		if ( $migrated ) {

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -935,6 +935,8 @@ class ConstantContact_Lists {
 			}
 		}
 
+		$forms_query->rewind_posts();
+
 		error_log( '$v2_list_ids ' . var_export( $v2_list_ids, true ) );
 
 		$v2_list_ids_string = implode( ',', $v2_list_ids );

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -68,6 +68,7 @@ class ConstantContact_Lists {
 		add_action( 'admin_init', [ $this, 'maybe_display_duplicate_list_error' ] );
 
 		add_action( 'constant_contact_sync_lists', [ $this, 'migrate_v2_v3_form_lists' ] );
+		add_action( 'update_option_ctct_options_settings', [ $this, 'migrate_v2_v3_form_lists' ] );
 	}
 
 	/**

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -923,8 +923,6 @@ class ConstantContact_Lists {
 			$forms_query->the_post();
 			$list_ids  = get_post_meta( get_the_ID(), '_ctct_list', true );
 
-			error_log( '$list_ids ' . var_export( $list_ids, true ) );
-
 			if ( is_array( $list_ids ) && ! empty( $list_ids[0] ) ) {
 				foreach ( $list_ids as $list_id ) {
 					// Only update v2 list IDs.
@@ -937,16 +935,11 @@ class ConstantContact_Lists {
 
 		$forms_query->rewind_posts();
 
-		error_log( '$v2_list_ids ' . var_export( $v2_list_ids, true ) );
-
 		$v2_list_ids_string = implode( ',', $v2_list_ids );
-		error_log( '$v2_list_ids_string ' . var_export( $v2_list_ids_string, true ) );
 
 		// Get the list ID cross references.
 		$list_x_refs = [];
 		$list_x_refs = $this->get_v2_list_id_x_refs( $v2_list_ids_string );
-
-		error_log( '$list_x_refs ' . var_export( $list_x_refs, true ) );
 
 		// Iterate over forms and update list IDs.
 		while( $forms_query->have_posts() ) {
@@ -972,7 +965,6 @@ class ConstantContact_Lists {
 				}
 			}
 
-			error_log( '$updated_list_ids ' . var_export( $updated_list_ids, true ) );
 			// Update the current form's list IDs.
 			if ( ! empty( $updated_list_ids ) ) {
 				update_post_meta( get_the_ID(), '_ctct_list', $updated_list_ids );

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -898,6 +898,9 @@ class ConstantContact_Lists {
 		);
 
 		if ( ! $query->have_posts() ) {
+			// There were no forms to update. Flag the migration as complete.
+			//update_option( 'ctct_api_v2_v3_migrated', true );
+
 			return;
 		}
 
@@ -912,6 +915,7 @@ class ConstantContact_Lists {
 
 		$new_list_ids = $this->get_new_ids_from_list( $lists );
 
+		error_log( '$new_list_ids ' . var_export( $new_list_ids, true ) );
 		return;
 		#return update_option( 'ctct_api_v2_v3_migrated', true );
 	}
@@ -926,9 +930,11 @@ class ConstantContact_Lists {
 
 		foreach( $list_chunks as $list_chunk ) {
 			$list_string = implode( ',', $list_chunk );
-			$new_pairs[] = constantcontact_api()->get_updated_lists_ids( $list_string );
+			//$new_pairs[] = constantcontact_api()->get_updated_lists_ids( $list_string );
+			$new_pairs[] = constantcontact_api()->client()->get_updated_lists_ids( $list_string );
 		}
 
+		error_log( '$new_pairs ' . var_export( $new_pairs, true ) );
 		return $new_pairs;
 	}
 }

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -67,8 +67,11 @@ class ConstantContact_Lists {
 
 		add_action( 'admin_init', [ $this, 'maybe_display_duplicate_list_error' ] );
 
+		// Attempt to migrate v2 to v3 lists when syncing lists manually.
 		add_action( 'constant_contact_sync_lists', [ $this, 'migrate_v2_v3_form_lists' ] );
-		add_action( 'update_option_ctct_options_settings', [ $this, 'migrate_v2_v3_form_lists' ] );
+
+		// Attempt to migrate v2 to v3 lists automatically upon account authentication.
+		add_action( 'update_option__ctct_access_token', [ $this, 'migrate_v2_v3_form_lists' ] );
 	}
 
 	/**

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -914,6 +914,7 @@ class ConstantContact_Lists {
 			return update_option( 'ctct_api_v2_v3_migrated', true );
 		}
 
+		// Get all the v2 List IDs.
 		$v2_list_ids = [];
 		while( $forms_query->have_posts() ) {
 			$forms_query->the_post();
@@ -950,7 +951,7 @@ class ConstantContact_Lists {
 
 			if ( is_array( $list_ids ) && ! empty( $list_ids[0] ) ) {
 				foreach ( $list_ids as $list_id ) {
-					// V3 List IDs do not need to be modified.
+					// V3 List IDs do not need to be modified. We will save them as-is.
 					if ( ! $this->is_v2_list_id( $list_id ) && ! in_array( $list_id , $updated_list_ids ) ) {
 						$updated_list_ids[] = $list_id;
 						continue;
@@ -973,6 +974,7 @@ class ConstantContact_Lists {
 			}
 		}
 
+		// Set flag indicating that list ID migration is complete.
 		return update_option( 'ctct_api_v2_v3_migrated', true );
 	}
 

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -370,7 +370,7 @@ class ConstantContact_Process_Form {
 			(
 				! isset( $cleaned_values['ctct-lists'] ) ||
 				empty( $cleaned_values['ctct-lists'] ) ||
-				empty( $cleaned_values['ctct-lists'][0] )
+				empty( $cleaned_values['ctct-lists']['value'][0] )
 			)
 		) {
 			return [

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -365,7 +365,14 @@ class ConstantContact_Process_Form {
 		$cleaned_values = $this->clean_values( $return['values'] );
 
 		// Require at least one list to be selected.
-		if ( constant_contact()->api->is_connected() && ( ! isset( $cleaned_values['ctct-lists'] ) || empty( $cleaned_values['ctct-lists'] ) ) ) {
+		if (
+			constant_contact()->api->is_connected() &&
+			(
+				! isset( $cleaned_values['ctct-lists'] ) ||
+				empty( $cleaned_values['ctct-lists'] ) ||
+				empty( $cleaned_values['ctct-lists'][0] )
+			)
+		) {
 			return [
 				'status' => 'named_error',
 				'error'  => __( 'Please select at least one list to subscribe to.', 'constant-contact-forms' ),

--- a/includes/class-uninstall.php
+++ b/includes/class-uninstall.php
@@ -85,6 +85,7 @@ class ConstantContact_Uninstall {
 			'ctct_auth_url',
 			'ctct_key',
 			'ctct_exceptions_exist',
+			'ctct_api_v2_v3_migrated',
 			Constant_Contact::$activated_date_option,
 			ConstantContact_Notifications::$dismissed_notices_option,
 			ConstantContact_Notifications::$review_dismissed_option,


### PR DESCRIPTION
Closes CC-346

## Description
Updates list IDs associated with forms from the API v2 format `1033695742` to the API v3 format `d995db16-aca3-11ed-b85b-fa163ec0786c`.

The forms' list migration will be run automatically when syncing lists or when authenticating with Constant Contact.

Once the forms' list migration has been performed, it will not run again.


### Testing
1. Install the current 1.13.0 version of the plugin (API v2)

2. Create some lists and add them to a form.

3. Install this branch of the plugin (`fix/cc-346-update-forms-lists-id` API V3)

4. Connect your account. 

5. Visit the form that you set up in step 1. The lists that you associated should still be checked off.

