### PR TITLE
Amend our option override processes and where we save settings. On op…

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -975,7 +975,11 @@ class ConstantContact_Settings {
 	 * @return mixed Site option
 	 */
 	public function get_override( $deprecated, $default = false ) {
-		return get_site_option( $this->key, $default );
+		$option = get_option( $this->key, $default );
+		if ( empty( $option ) ) {
+			$option = get_site_option( $this->key, $default );
+		}
+		return $option;
 	}
 
 	/**
@@ -988,7 +992,7 @@ class ConstantContact_Settings {
 	 * @return mixed Site option
 	 */
 	public function update_override( $deprecated, $option_value ) {
-		return update_site_option( $this->key, $option_value );
+		return update_option( $this->key, $option_value );
 	}
 
 	/**


### PR DESCRIPTION
…tion get, check and return if we have a per-site option first, otherwise fall back to

network option.

On save, no longer save via site option regardless of MS status, allowing each individual site to have their own.

Hopefully this will be a seamless upgrade once users start saving settings, minimal to no settings loss.