### PR TITLE
Feature/cc 386 remove cron delay

### DIFF
--- a/includes/class-health.php
+++ b/includes/class-health.php
@@ -93,10 +93,6 @@ class ConstantContact_Health {
 					'value' => $logs_writeable,
 				],
 				[
-					'label' => esc_html__( 'Opt in cron scheduled?', 'constant-contact-forms' ),
-					'value' => ( wp_next_scheduled( 'ctct_schedule_form_opt_in' ) ) ? $yes : $no,
-				],
-				[
 					'label' => esc_html__( 'Token refresh cron scheduled?', 'constant-contact-forms' ),
 					'value' => ( wp_next_scheduled( 'refresh_token_job' ) ) ? $yes : $no,
 				],

--- a/includes/class-mail.php
+++ b/includes/class-mail.php
@@ -38,13 +38,11 @@ class ConstantContact_Mail {
 	}
 
 	/**
-	 * Fire hoosk for actions.
+	 * Fire hooks for actions.
 	 *
 	 * @since 1.0.0
 	 */
-	protected function hooks() {
-		add_action( 'ctct_schedule_form_opt_in', [ $this, 'opt_in_user' ] );
-	}
+	protected function hooks() {}
 
 	/**
 	 * Process our form values.
@@ -61,26 +59,7 @@ class ConstantContact_Mail {
 			return false;
 		}
 
-		$values = constant_contact()->process_form->clean_values( $values );
-
-		if ( $add_to_opt_in && constant_contact()->api->is_connected() ) {
-
-			$maybe_bypass = constant_contact_get_option( '_ctct_bypass_cron', '' );
-			$cron_disabled = ( defined( 'DISABLE_WP_CRON' ) && true === DISABLE_WP_CRON );
-			if ( 'on' !== $maybe_bypass && ! $cron_disabled ) {
-				/**
-				 * Filters the delay between scheduling of the opt-in e-mail event.
-				 *
-				 * @since 1.0.2
-				 *
-				 * @param int $schedule_delay The time to add to `time()` for the event.
-				 */
-				$schedule_delay = apply_filters( 'constant_contact_opt_in_delay', MINUTE_IN_SECONDS );
-
-				wp_schedule_single_event( current_time( 'timestamp' ) + absint( $schedule_delay ), 'ctct_schedule_form_opt_in', [ $values ] );
-			}
-		}
-
+		$values         = constant_contact()->process_form->clean_values( $values );
 		$opt_in_details = ( isset( $values['ctct-opt-in'] ) ) ? $values['ctct-opt-in'] : [];
 
 		// Preserve form ID for mail() method. Lost in pretty_values() pass.

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -398,10 +398,8 @@ class ConstantContact_Process_Form {
 				constant_contact()->mail->submit_form_values( $return['values'] );
 			} else {
 				// No need to check for opt in status because we would have returned early by now if false.
-				$maybe_bypass = constant_contact_get_option( '_ctct_bypass_cron', '' );
-				$cron_disabled = ( defined( 'DISABLE_WP_CRON' ) && true === DISABLE_WP_CRON );
 
-				if ( constant_contact()->api->is_connected() && 'on' === $maybe_bypass || $cron_disabled ) {
+				if ( constant_contact()->api->is_connected() ) {
 					constant_contact()->mail->submit_form_values( $return['values'] ); // Emails but doesn't schedule cron.
 
 					$api_result = constant_contact()->mail->opt_in_user( $this->clean_values( $return['values'] ) );

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -363,10 +363,12 @@ class ConstantContact_Settings {
 			$cmb->add_field(
 				[
 					'name'       => esc_html__( 'Bypass Constant Contact cron scheduling', 'constant-contact-forms' ),
-					'desc'       => esc_html__( 'This option will send form entries to Constant Contact right away instead of holding for one minute delay.', 'constant-contact-forms' ),
+					'desc'       => esc_html__( 'Version 2.3.0 introduces bypassing by default for all submissions. This setting is disabled. It will be removed in a future version.', 'constant-contact-forms' ),
 					'id'         => '_ctct_bypass_cron',
 					'type'       => 'checkbox',
 					'before_row' => '<hr/>',
+					'default'    => 'on',
+					'attributes' => [ 'disabled' => true ],
 				]
 			);
 


### PR DESCRIPTION
Remove our checks for bypassing cron because we're not going to schedule it in the first place. Only reliance we need to send to the API now is being presently connected.