### PR TITLE
make sure we have anything in $_POST before we proceed

### DIFF
--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -190,6 +190,10 @@ class ConstantContact_Process_Form {
 
 		if ( empty( $data ) ) {
 
+			if ( empty( $_POST ) ) {
+				return;
+			}
+
 			$data = $_POST; // @codingStandardsIgnoreLine
 		}
 


### PR DESCRIPTION
We assume we have `$_POST` at all originally, but we technically may not. Thus we're going to return early if we have nothing.

Most everything beyond that SHOULD be checking and still returning early, but just in case something wonky is going on behind the scenes, let's just exit if we have nothing.