### PR TITLE
set the address kind outside of switch statement

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -920,10 +920,11 @@ class ConstantContact_API {
 						$address = [];
 					}
 
+					$address['kind'] = 'home';
+
 					switch ( $key ) {
 						case 'street_address':
-							$address['kind'] = 'home';
-							$streets[]       = $value;
+							$streets[] = $value;
 							break;
 						case 'line_2_address':
 							$streets[] = $value;


### PR DESCRIPTION
This PR moves the `$address['kind']` assignment outside of the switch statement, to consistently set regardless of which address fields are used.