### PR TITLE
Feature/cc 417 enhanced spam checks

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -749,10 +749,12 @@ class ConstantContact_API {
 			is_array( $return_contact ) &&
 			array_key_exists( 'action', $return_contact ) &&
 			in_array(
-				$return_contact['action'], [
+				$return_contact['action'],
+				[
 					'created',
 					'updated'
-				]
+				],
+				true
 			)
 		) {
 			$new_contact = $this->clear_email( $new_contact );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -745,9 +745,20 @@ class ConstantContact_API {
 			$this->log_errors( $our_errors );
 		}
 
-		$new_contact = $this->clear_email( $new_contact );
-		$new_contact = $this->clear_phone( $new_contact );
-		constant_contact_maybe_log_it( 'API', 'Submitted contact data', $new_contact );
+		if (
+			is_array( $return_contact ) &&
+			array_key_exists( 'action', $return_contact ) &&
+			in_array(
+				$return_contact['action'], [
+					'created',
+					'updated'
+				]
+			)
+		) {
+			$new_contact = $this->clear_email( $new_contact );
+			$new_contact = $this->clear_phone( $new_contact );
+			constant_contact_maybe_log_it( 'API', 'Submitted contact data', $new_contact );
+		}
 
 		return $return_contact;
 	}

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -430,7 +430,15 @@ class ConstantContact_Process_Form {
 					} else if ( is_array( $api_result ) && 1 === count( $api_result ) ) {
 						$api_error = $api_result[0];
 
-						if ( array_key_exists( 'error_key', $api_error ) && 'contacts.api.validation.error' === $api_error['error_key'] && ( 'Email address is invalid' === $api_error['error_message'] || 'Address format' === $api_error['error_message'] ) ) {
+						if (
+							array_key_exists( 'error_key', $api_error ) &&
+							array_key_exists( 'error_message', $api_error ) &&
+							'contacts.api.validation.error' === $api_error['error_key'] &&
+							(
+								'Email address is invalid' === $api_error['error_message'] ||
+								'Address format' === $api_error['error_message']
+							)
+						) {
 							return [
 								'status'  => 'api_error',
 								'message' => __( 'An error occurred while attempting Constant Contact API request. Please check your details and try again.', 'constant-contact-forms' ),

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -430,7 +430,7 @@ class ConstantContact_Process_Form {
 					} else if ( is_array( $api_result ) && 1 === count( $api_result ) ) {
 						$api_error = $api_result[0];
 
-						if ( array_key_exists( 'error_key', $api_error ) && 'contacts.api.validation.error' === $api_error['error_key'] && 'Email address is invalid' === $api_error['error_message'] ) {
+						if ( array_key_exists( 'error_key', $api_error ) && 'contacts.api.validation.error' === $api_error['error_key'] && ( 'Email address is invalid' === $api_error['error_message'] || 'Address format' === $api_error['error_message'] ) ) {
 							return [
 								'status'  => 'api_error',
 								'message' => __( 'An error occurred while attempting Constant Contact API request. Please check your details and try again.', 'constant-contact-forms' ),


### PR DESCRIPTION
This PR adds some extra checks regarding API responses that indicate probable spam responses to submitted emails. If a request is determined to probably be spam, we prevent a notification email from being sent to the site owner.

This will help prevent issues around a notification received about a new signup, but the account owner checking their account to find no signup in the actual list.

It'll also still surface an error to the form via a success/failure notification at the top of the form output.

It also adds in not logging of these spam results to help clean up error logs a bit.