### PR TITLE
Fix/cc 440 comment login signup errors

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -746,12 +746,14 @@ class ConstantContact_Settings {
 		if ( ! constant_contact()->api->is_connected() ) {
 			return;
 		}
+		$lists = $this->get_optin_list_options();
+
+		if ( empty( $lists ) ) {
+			return;
+		}
 
 		$saved_label = constant_contact_get_option( '_ctct_optin_label', '' );
-
-		$lists = $this->get_optin_list_options();
-		$label = $saved_label ?: esc_html__( 'Sign up to our newsletter.', 'constant-contact-forms' );
-
+		$label       = $saved_label ?: esc_html__( 'Sign up to our newsletter.', 'constant-contact-forms' );
 		?>
 		<p class="ctct-optin-wrapper" style="padding: 0 0 1em 0;">
 			<p><?php echo esc_attr( $label ); ?></p>

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -372,7 +372,20 @@ class ConstantContact_Settings {
 				]
 			);
 
-			$lists = constant_contact()->builder->get_lists();
+			$lists     = constant_contact()->builder->get_lists();
+			$woo_lists = [
+				'WooCommerce - All Customers',
+				'WooCommerce - First time Customers',
+				'WooCommerce - Lapsed Customers',
+				'WooCommerce - Potential Customers',
+				'WooCommerce - Recent Customers',
+				'WooCommerce - Repeat Customers',
+			];
+			foreach( $lists as $list_id => $list_name ) {
+				if ( in_array( $list_name, $woo_lists ) ) {
+					unset( $lists[ $list_id ] );
+				}
+			}
 
 			if ( $lists && is_array( $lists ) ) {
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1138,7 +1138,7 @@ function constant_contact_get_option( $key = '', $default = null ) {
 		return cmb2_get_option( constant_contact()->settings->key, $key, $default );
 	}
 
-	$options = get_option( constant_contact()->settings->key, $key, $default );
+	$options = get_option( $key, $default );
 	$value   = $default;
 
 	if ( 'all' === $key ) {

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -404,8 +404,6 @@ class ConstantContact_Settings {
 					]
 				);
 
-				$lists[0] = esc_html__( 'Select a list', 'constant-contact-forms' );
-
 				$cmb->add_field(
 					[
 						'name'             => esc_html__( 'Add subscribers to', 'constant-contact-forms' ),

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1091,7 +1091,7 @@ class ConstantContact_Settings {
 	}
 
 	/**
-	 * Returns formated list of available lists during opt-in.
+	 * Returns formatted list of available lists during opt-in.
 	 *
 	 * @author Scott Anderson <scott.anderson@webdevstudios.com>
 	 * @since  1.12.0
@@ -1112,8 +1112,11 @@ class ConstantContact_Settings {
 			];
 			$list      = get_posts( $list_args );
 
-			$formatted_lists[ $list_id ] = $list[0]->post_title;
+			if ( ! empty( $list ) ) {
+				$formatted_lists[ $list_id ] = $list[0]->post_title;
+			}
 		}
+
 		return $formatted_lists;
 	}
 }


### PR DESCRIPTION
This PR protects against empty results for formatted list arrays.

It also touches up some list management in similar ways we do elsewhere for the plugin, as well as some logic touchups and invalid get_option usage.