### PR TITLE
Feature/cc 438 failed disconnect submission hardening

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1647,7 +1647,7 @@ class ConstantContact_API {
 	 * form submission that will be re-processed once new tokens are established. We are
 	 * not going to worry about listing the form name, because all forms would be affected.
 	 *
-	 * @since NEXT
+	 * @since 2.7.0
 	 *
 	 * @param $form_id
 	 */
@@ -1679,7 +1679,7 @@ class ConstantContact_API {
 				/**
 				 * Filters the email subject to be sent to an admin.
 				 *
-				 * @since NEXT
+				 * @since 2.7.0
 				 *
 				 * @param string $value Constructed email subject.
 				 * @param string $value Constant Contact Form ID.
@@ -1694,7 +1694,7 @@ class ConstantContact_API {
 	/**
 	 * Set our email's content type.
 	 *
-	 * @since NEXT
+	 * @since 2.7.0
 	 *
 	 * @return string
 	 */

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1580,7 +1580,7 @@ class ConstantContact_API {
 	 * @param string $type    API request type.
 	 * @param array  $request The request.
 	 */
-	private function log_missed_api_request( string $type, array $request ) {
+	public function log_missed_api_request( string $type, array $request ) {
 		$missed_api_requests            = get_option( 'ctct_missed_api_requests', [] );
 		$missed_api_requests[][ $type ] = $request;
 		update_option( 'ctct_missed_api_requests', $missed_api_requests );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1584,6 +1584,8 @@ class ConstantContact_API {
 		$missed_api_requests            = get_option( 'ctct_missed_api_requests', [] );
 		$missed_api_requests[][ $type ] = $request;
 		update_option( 'ctct_missed_api_requests', $missed_api_requests );
+
+		$this->api_errors_admin_email( $request['form_id'] );
 	}
 
 	/**
@@ -1635,6 +1637,69 @@ class ConstantContact_API {
 		if ( empty( $missed_api_requests ) ) {
 			update_option( 'ctct_missed_api_requests', $missed_api_requests );
 		}
+	}
+
+	/**
+	 * Email site administrator email and any custom email address set to be notified of new entries.
+	 *
+	 * This method is meant to notify that there are API errors being detected, and that
+	 * a new connection should be established. This will be after temporarily storing a
+	 * form submission that will be re-processed once new tokens are established. We are
+	 * not going to worry about listing the form name, because all forms would be affected.
+	 *
+	 * @since NEXT
+	 *
+	 * @param $form_id
+	 */
+	protected function api_errors_admin_email( $form_id ) {
+		$send_to_addresses[] = get_option( 'admin_email' );
+		$custom              = get_post_meta( $form_id, '_ctct_email_settings', true );
+		if ( ! empty( $custom ) ) {
+			$send_to_addresses[] = $custom;
+		}
+		$title = get_bloginfo( 'blogname' );
+
+		$content = esc_html__(
+			'We have detected potential connection errors for the %s%s%s site. We have captured a failed signup, and will retry adding them once a fresh connection has been established. Please visit the site and re-take the connection steps at your earliest convenience.',
+			'constant-contact-forms'
+		);
+		$content = sprintf(
+			$content,
+			sprintf(
+				'<a href="%s">',
+				get_bloginfo( 'url' )
+			),
+			$title,
+			'</a>'
+		);
+		add_filter( 'wp_mail_content_type', [ $this, 'set_email_type' ] );
+		foreach ( $send_to_addresses as $address ) {
+			wp_mail(
+				$address,
+				/**
+				 * Filters the email subject to be sent to an admin.
+				 *
+				 * @since NEXT
+				 *
+				 * @param string $value Constructed email subject.
+				 * @param string $value Constant Contact Form ID.
+				 */
+				apply_filters( 'constant_contact_api_errors_admin_email_subject', esc_html__( 'Potential Constant Contact Forms issues.', 'constant-contact-forms' ), $form_id ),
+				$content
+			);
+		}
+		remove_filter( 'wp_mail_content_type', [ $this, 'set_email_type' ] );
+	}
+
+	/**
+	 * Set our email's content type.
+	 *
+	 * @since NEXT
+	 *
+	 * @return string
+	 */
+	public function set_email_type() {
+		return 'text/html';
 	}
 }
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1660,7 +1660,7 @@ class ConstantContact_API {
 		$title = get_bloginfo( 'blogname' );
 
 		$content = esc_html__(
-			'We have detected potential connection errors for the %s%s%s site. We have captured a failed signup, and will retry adding them once a fresh connection has been established. Please visit the site and re-take the connection steps at your earliest convenience.',
+			'We have detected potential connection errors for your site, %s%s%s. A failed signup has been detected and will be retried automatically once a new connection has been established. Please visit your site and perform the steps to reconnect the plugin at your earliest convenience.',
 			'constant-contact-forms'
 		);
 		$content = sprintf(

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -519,8 +519,8 @@ class ConstantContact_Display {
 			}
 		}
 
-		if ( constant_contact()->api->is_connected() && isset( $form_data['options'] ) ) {
-			$lists = maybe_unserialize( isset( $form_data['options']['optin']['list'] ) ? $form_data['options']['optin']['list'] : '' );
+		if ( isset( $form_data['options']['optin']['list'] ) ) {
+			$lists = maybe_unserialize( $form_data['options']['optin']['list'] );
 
 			$return .= $this->field(
 				[

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -449,6 +449,32 @@ class ConstantContact_Process_Form {
 						constant_contact()->mail->submit_form_values( $return['values'] ); // Emails but doesn't schedule cron.
 					}
 				} else {
+					// We have at least one list, but are not considered connected.
+					if (
+						! constant_contact()->api->is_connected() &&
+						! empty( $cleaned_values['ctct-lists']['value'][0] )
+					) {
+						$email = '';
+						foreach ( $cleaned_values as $index => $string ) {
+							if ( false !== strpos( $index, 'email' ) ) {
+								$email = $string['value'];
+							}
+						}
+						// At this point, something is likely going on,
+						// so after the 2nd attempt, we will log the attempt for later.
+						foreach( $cleaned_values['ctct-lists']['value'] as $chosen => $list ) {
+							constant_contact()->api->log_missed_api_request(
+								'contact_add_update',
+								[
+									'list'    => $list,
+									'email'   => $email,
+									'contact' => $new_contact, // all of the field info
+									'form_id' => $cleaned_values['ctct-id']['value'],
+								]
+							);
+						}
+						constant_contact_maybe_log_it( 'API', 'A failed API attempt was caught and will be retried after reconnection.' );
+					}
 					constant_contact()->mail->submit_form_values( $return['values'], true );
 				}
 			}

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -460,6 +460,27 @@ class ConstantContact_Process_Form {
 								$email = $string['value'];
 							}
 						}
+
+						$new_contact = [];
+						foreach ( $cleaned_values as $key => $val ) {
+							$key  = sanitize_text_field( $val['key'] ?? '' );
+							$orig = sanitize_text_field( $val['orig_key'] ?? '' );
+							$val  = sanitize_text_field( $val['value'] ?? '' );
+
+							if ( empty( $key ) || in_array( $key, [ 'ctct-opt-in', 'ctct-id', 'ctct-lists' ], true ) ) {
+								continue;
+							}
+
+							$new_contact[ $orig ] = [
+								'key' => $key,
+								'val' => $val,
+							];
+
+							if ( 'email' === $key ) {
+								$new_contact['email'] = $val;
+							}
+						}
+
 						// At this point, something is likely going on,
 						// so after the 2nd attempt, we will log the attempt for later.
 						foreach( $cleaned_values['ctct-lists']['value'] as $chosen => $list ) {


### PR DESCRIPTION
This PR amends our form display to still show list options regardless of detected connection status, and still allows attempt to submit a form entry to the API.

If the request fails, which should be the case for these changes, the entry attempt will be added to our logged attempts that will be re-attempted upon fresh connection status.

On top of that, to help hasten site admins re-establishing a connect, we will email the admin users any time that `log_missed_api_request()` is triggered. This will more actively notify of issues, instead of potentially waiting weeks or longer before everything is processed.