### PR TITLE
Feature/cc 454 duplicate form quick link

### DIFF
--- a/includes/class-cpts.php
+++ b/includes/class-cpts.php
@@ -448,7 +448,7 @@ class ConstantContact_CPTS {
 			}
 			$copied_meta['custom_fields_group'] = maybe_unserialize( $meta_keys['custom_fields_group'][0] );
 
-			foreach( $copied_meta as $meta_key => $meta_value ) {
+			foreach ( $copied_meta as $meta_key => $meta_value ) {
 				update_post_meta( $copied_form_post_id, $meta_key, $meta_value );
 			}
 

--- a/includes/class-cpts.php
+++ b/includes/class-cpts.php
@@ -410,21 +410,23 @@ class ConstantContact_CPTS {
 
 			$copied_form_post_id = wp_insert_post( $form_args );
 
-			/*
-			 * Need to get all of OUR meta keys, and iterate over them. Fetch from builder fields page.
-			 * Instead of trying a $wpdb call, since we're not hitting all at once
-			 * let's use update_post_meta() with our $copied_form_post_id
-			 *
-			 * Current known:
-			 * _ctct_verify_key
-				_ctct_has_email_field
-				_ctct_list
-				_ctct_button_text
-				_ctct_form_submission_success
-				_ctct_opt_in_instructions
-				custom_fields_group
-				_ctct_description
-			 */
+			$meta_keys   = get_post_meta( $to_copy_post->ID );
+			$copied_meta = [];
+			foreach ( $meta_keys as $meta_key => $meta_key_value ) {
+				// WP has a polyfill for this PHP8 function
+				if ( str_starts_with( $meta_key, '_ctct_' ) ) {
+					$copied_meta[ $meta_key ] = maybe_unserialize( $meta_key_value[0] );
+				}
+			}
+			$copied_meta['custom_fields_group'] = maybe_unserialize( $meta_keys['custom_fields_group'][0] );
+
+			foreach( $copied_meta as $meta_key => $meta_value ) {
+				update_post_meta( $copied_form_post_id, $meta_key, $meta_value );
+			}
+
+			return $copied_form_post_id;
 		}
+
+		return false;
 	}
 }

--- a/includes/class-cpts.php
+++ b/includes/class-cpts.php
@@ -52,6 +52,7 @@ class ConstantContact_CPTS {
 
 		add_filter( 'post_row_actions', [ $this, 'duplicate_form_link' ], 10, 2 );
 		add_action( 'admin_menu', [ $this, 'maybe_duplicate_form' ] );
+		add_action( 'admin_notices', [ $this, 'admin_notices' ] );
 	}
 
 	/**
@@ -428,5 +429,33 @@ class ConstantContact_CPTS {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Add an admin notice with success or failure messaging for form duplication attempts.
+	 *
+	 * @since NEXT
+	 */
+	public function admin_notices() {
+		if ( empty( $_GET ) ) {
+			return;
+		}
+
+		if ( empty( $_GET['ctct_duplicate_form_success'] ) ) {
+			return;
+		}
+
+		$message = ( 'true' === sanitize_text_field( $_GET['ctct_duplicate_form_success'] ) ) ?
+			esc_html__( 'Constant Contact Forms form duplication succeeded.', 'constant-contact-forms' ) :
+			esc_html__( 'Constant Contact Forms form duplication failed.', 'constant-contact-forms' );
+		$type    = ( 'true' === sanitize_text_field( $_GET['ctct_duplicate_form_success'] ) ) ? 'success' : 'error';
+		wp_admin_notice(
+			$message,
+			array(
+				'id'          => 'ctct_form_duplication_notice',
+				'type'        => $type,
+				'dismissible' => true,
+			)
+		);
 	}
 }

--- a/includes/class-cpts.php
+++ b/includes/class-cpts.php
@@ -341,7 +341,7 @@ class ConstantContact_CPTS {
 	/**
 	 * Add a "Duplicate form" action to forms in our `ctct_forms` list table.
 	 *
-	 * @since NEXT
+	 * @since 2.8.0
 	 *
 	 * @param array   $actions Current array of actions for a post in the list table,
 	 * @param WP_Post $post    Post object for the current post being listed.
@@ -375,7 +375,7 @@ class ConstantContact_CPTS {
 	/**
 	 * Maybe prrocess a clicked "Duplicate form" link.
 	 *
-	 * @since NEXT
+	 * @since 2.8.0
 	 */
 	public function maybe_duplicate_form() {
 		if ( empty( $_GET ) ) {
@@ -412,10 +412,9 @@ class ConstantContact_CPTS {
 	/**
 	 * Perform a duplication of a clicked form.
 	 *
-	 * @since NEXT
+	 * @since 2.8.0
 	 *
 	 * @param int $post_id Form ID to duplicate.
-	 *
 	 * @return false|int|WP_Error
 	 */
 	protected function duplicate_form( int $post_id ) {
@@ -461,7 +460,7 @@ class ConstantContact_CPTS {
 	/**
 	 * Add an admin notice with success or failure messaging for form duplication attempts.
 	 *
-	 * @since NEXT
+	 * @since 2.8.0
 	 */
 	public function admin_notices() {
 		if ( empty( $_GET ) ) {

--- a/includes/class-cpts.php
+++ b/includes/class-cpts.php
@@ -338,6 +338,16 @@ class ConstantContact_CPTS {
 		return $forms;
 	}
 
+	/**
+	 * Add a "Duplicate form" action to forms in our `ctct_forms` list table.
+	 *
+	 * @since NEXT
+	 *
+	 * @param array   $actions Current array of actions for a post in the list table,
+	 * @param WP_Post $post    Post object for the current post being listed.
+	 *
+	 * @return array
+	 */
 	public function duplicate_form_link( $actions, $post ) {
 		if ( 'ctct_forms' !== $post->post_type ) {
 			return $actions;
@@ -362,6 +372,11 @@ class ConstantContact_CPTS {
 		return $actions;
 	}
 
+	/**
+	 * Maybe prrocess a clicked "Duplicate form" link.
+	 *
+	 * @since NEXT
+	 */
 	public function maybe_duplicate_form() {
 		if ( empty( $_GET ) ) {
 			return;
@@ -391,7 +406,16 @@ class ConstantContact_CPTS {
 		}
 	}
 
-	protected function duplicate_form( $post_id ) {
+	/**
+	 * Perform a duplication of a clicked form.
+	 *
+	 * @since NEXT
+	 *
+	 * @param int $post_id Form ID to duplicate.
+	 *
+	 * @return false|int|WP_Error
+	 */
+	protected function duplicate_form( int $post_id ) {
 		$to_copy_post = get_post( $post_id );
 		$curr_user    = wp_get_current_user();
 		$to_be_author = $curr_user->ID;

--- a/includes/class-cpts.php
+++ b/includes/class-cpts.php
@@ -374,7 +374,19 @@ class ConstantContact_CPTS {
 				wp_die( esc_html__( 'No form to duplicate has been supplied.', 'constant-contact-forms' ) );
 			}
 
-			$this->duplicate_form( absint( $_GET['post_id'] ) );
+			$returned_id = $this->duplicate_form( absint( $_GET['post_id'] ) );
+
+			if ( $returned_id ) {
+				wp_safe_redirect(
+					add_query_arg(
+						[
+							'success' => 'true'
+						],
+						admin_url( 'edit.php?post_type=ctct_forms' )
+					)
+				);
+				exit();
+			}
 		}
 	}
 

--- a/includes/class-cpts.php
+++ b/includes/class-cpts.php
@@ -377,4 +377,42 @@ class ConstantContact_CPTS {
 			$this->duplicate_form( absint( $_GET['post_id'] ) );
 		}
 	}
+
+	protected function duplicate_form( $post_id ) {
+		$to_copy_post = get_post( $post_id );
+		$curr_user    = wp_get_current_user();
+		$to_be_author = $curr_user->ID;
+
+		if ( ! empty( $to_copy_post ) ) {
+			$form_args = [
+				'comment_status' => $to_copy_post->comment_status,
+				'ping_status'    => $to_copy_post->ping_status,
+				'post_author'    => $to_be_author,
+				'post_content'   => $to_copy_post->post_content,
+				'post_excerpt'   => $to_copy_post->post_excerpt,
+				'post_name'      => $to_copy_post->post_name,
+				'post_status'    => 'publish',
+				'post_title'     => $to_copy_post->post_title,
+				'post_type'      => 'ctct_forms',
+			];
+
+			$copied_form_post_id = wp_insert_post( $form_args );
+
+			/*
+			 * Need to get all of OUR meta keys, and iterate over them. Fetch from builder fields page.
+			 * Instead of trying a $wpdb call, since we're not hitting all at once
+			 * let's use update_post_meta() with our $copied_form_post_id
+			 *
+			 * Current known:
+			 * _ctct_verify_key
+				_ctct_has_email_field
+				_ctct_list
+				_ctct_button_text
+				_ctct_form_submission_success
+				_ctct_opt_in_instructions
+				custom_fields_group
+				_ctct_description
+			 */
+		}
+	}
 }

--- a/includes/class-cpts.php
+++ b/includes/class-cpts.php
@@ -392,17 +392,20 @@ class ConstantContact_CPTS {
 
 			$returned_id = $this->duplicate_form( absint( $_GET['post_id'] ) );
 
+			$success = 'false';
 			if ( $returned_id ) {
-				wp_safe_redirect(
-					add_query_arg(
-						[
-							'success' => 'true'
-						],
-						admin_url( 'edit.php?post_type=ctct_forms' )
-					)
-				);
-				exit();
+				$success = 'true';
 			}
+
+			wp_safe_redirect(
+				add_query_arg(
+					[
+						'ctct_duplicate_form_success' => $success
+					],
+					admin_url( 'edit.php?post_type=ctct_forms' )
+				)
+			);
+			exit();
 		}
 	}
 

--- a/includes/class-cpts.php
+++ b/includes/class-cpts.php
@@ -51,7 +51,7 @@ class ConstantContact_CPTS {
 		add_filter( 'enter_title_here', [ $this, 'change_default_title' ] );
 
 		add_filter( 'post_row_actions', [ $this, 'duplicate_form_link' ], 10, 2 );
-		add_action( 'admin_init', [ $this, 'maybe_duplicate_form' ] );
+		add_action( 'admin_menu', [ $this, 'maybe_duplicate_form' ] );
 	}
 
 	/**


### PR DESCRIPTION
This PR adds some "duplicate form" quick links in our `ctct_forms` post type list table.

This would be useful for people who want to create a very similar form without having to fill in everything again.