### PR TITLE
only add mmarketing message to email notifications if not connected, indicating already having an account

### DIFF
--- a/includes/class-mail.php
+++ b/includes/class-mail.php
@@ -321,12 +321,15 @@ class ConstantContact_Mail {
 
 		$content = $content_title . $content;
 
-		$content_after = sprintf(
-			/* Translators: placeholders provide Constant Contact link information. */
-			esc_html__( "Email marketing is a great way to stay connected and engage with visitors after they've left your site. Visit %1\$shttps://www.constantcontact.com/index?pn=miwordpress%2\$s to sign up for a Free Trial.", 'constant-contact-forms' ),
-			'<a href="https://www.constantcontact.com/index?pn=miwordpress">',
-			'</a>'
-		);
+		$content_after = '';
+		if ( ! constant_contact()->api->is_connected() ) {
+			$content_after = sprintf(
+				/* Translators: placeholders provide Constant Contact link information. */
+				esc_html__( "Email marketing is a great way to stay connected and engage with visitors after they've left your site. Visit %1\$shttps://www.constantcontact.com/index?pn=miwordpress%2\$s to sign up for a Free Trial.", 'constant-contact-forms' ),
+				'<a href="https://www.constantcontact.com/?pn=miwordpress">',
+				'</a>'
+			);
+		}
 
 		/**
 		 * Filters the final constructed email content to be sent to an admin.


### PR DESCRIPTION
This PR sets some marketing messaging to admin email notifications of new signups, if they don't have an existing connection already.