### PR TITLE
Release280 two

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
          "rm -rf ./phpcompat.xml.dist",
          "rm -rf ./phpunit.xml.dist",
          "rm -rf ./plugin-config.js",
+         "rm -rf ./src",
          "rm -rf ./tests",
          "rm -rf ./webpack.config.js",
          "@composer install --no-dev -a",

--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -12,7 +12,7 @@
  * Plugin Name: Constant Contact Forms for WordPress
  * Plugin URI:  https://www.constantcontact.com
  * Description: Be a better marketer. All it takes is Constant Contact email marketing.
- * Version:     2.7.0
+ * Version:     2.8.0
  * Author:      Constant Contact
  * Author URI:  https://www.constantcontact.com/index?pn=miwordpress
  * Requires PHP: 7.4
@@ -76,7 +76,7 @@ class Constant_Contact {
 	 * @since 1.0.0
 	 * @var string
 	 */
-	const VERSION = '2.7.0';
+	const VERSION = '2.8.0';
 
 	/**
 	 * URL of plugin directory.

--- a/includes/class-notifications.php
+++ b/includes/class-notifications.php
@@ -105,7 +105,7 @@ class ConstantContact_Notifications {
 					'ID'         => 'activation',
 					'callback'   => [ 'ConstantContact_Notification_Content', 'activation' ],
 					'require_cb' => function() {
-						return constant_contact_is_not_connected() && ( sanitize_text_field( $_GET['page'] ) ?? '' ) !== 'ctct_options_settings_auth'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Only used for boolean checks.
+						return constant_contact_is_not_connected() && ( isset( $_GET['page'] ) && sanitize_text_field( $_GET['page'] ) ?? '' ) !== 'ctct_options_settings_auth'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Only used for boolean checks.
 					},
 				],
 			]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "constant-contact-forms",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constant-contact-forms",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "",
   "main": "build/index.js",
   "engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      constantcontact, webdevstudios, tw2113, znowebdev, ggwicz, ra
 Tags: constant contact, constant contact official, marketing, newsletter, contacts
 Requires at least: 5.2.0
 Tested up to:      6.7.1
-Stable tag:        2.7.0
+Stable tag:        2.8.0
 License:           GPLv3
 License URI:       http://www.gnu.org/licenses/gpl-3.0.html
 Requires PHP:      7.4


### PR DESCRIPTION
This PR addresses missed version bumps in the release branch.

It also removes a `src` folder as part of our build collection process, and a php notice prevention.