### PR TITLE
Constant Contact Lists updates in various connective states.

### DIFF
--- a/includes/class-cpts.php
+++ b/includes/class-cpts.php
@@ -169,9 +169,7 @@ class ConstantContact_CPTS {
 			'capability_type'     => 'page',
 		];
 
-		if ( constantcontact_api()->is_connected() ) {
-			register_post_type( 'ctct_lists', $args );
-		}
+		register_post_type( 'ctct_lists', $args );
 	}
 
 	/**

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -837,7 +837,11 @@ class ConstantContact_Lists {
 
 		$link = wp_nonce_url( add_query_arg( [ 'ctct_list_sync' => 'true' ] ), 'ctct_resyncing', 'ctct_resyncing' );
 
-		$views['sync'] = '<strong><a href="' . $link . '">' . __( 'Sync Lists with Constant Contact', 'constant-contact-forms' ) . '</a></strong>';
+		if ( constant_contact()->api->is_connected() ) {
+			$views['sync'] = '<strong><a href="' . $link . '">' . esc_html__( 'Sync Lists with Constant Contact', 'constant-contact-forms' ) . '</a></strong>';
+		} elseif ( constant_contact_get_has_exceptions() ) {
+			$views['sync'] = '<strong><a href="' . $link . '">' . esc_html__( 'Fix connectivity issues', 'constant-contact-forms' ) . '</a></strong>';
+		}
 
 		return $views;
 	}

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -835,12 +835,13 @@ class ConstantContact_Lists {
 	 */
 	public function add_force_sync_button( $views ) {
 
-		$link = wp_nonce_url( add_query_arg( [ 'ctct_list_sync' => 'true' ] ), 'ctct_resyncing', 'ctct_resyncing' );
+		$reconnect_link = admin_url( 'edit.php?post_type=ctct_forms&page=ctct_options_connect' );
+		$sync_link = wp_nonce_url( add_query_arg( [ 'ctct_list_sync' => 'true' ] ), 'ctct_resyncing', 'ctct_resyncing' );
 
-		if ( constant_contact()->api->is_connected() ) {
-			$views['sync'] = '<strong><a href="' . $link . '">' . esc_html__( 'Sync Lists with Constant Contact', 'constant-contact-forms' ) . '</a></strong>';
-		} elseif ( constant_contact_get_has_exceptions() ) {
-			$views['sync'] = '<strong><a href="' . $link . '">' . esc_html__( 'Fix connectivity issues', 'constant-contact-forms' ) . '</a></strong>';
+		if ( constant_contact_get_needs_manual_reconnect() ) {
+			$views['reconnect'] = '<strong><a href="' . $reconnect_link . '">' . esc_html__( 'Fix connectivity issues', 'constant-contact-forms' ) . '</a></strong>';
+		} else if ( constant_contact()->api->is_connected() ) {
+			$views['sync'] = '<strong><a href="' . $sync_link . '">' . esc_html__( 'Sync Lists with Constant Contact', 'constant-contact-forms' ) . '</a></strong>';
 		}
 
 		return $views;

--- a/includes/class-notification-content.php
+++ b/includes/class-notification-content.php
@@ -337,14 +337,21 @@ class ConstantContact_Notification_Content {
 	}
 
 	public static function lists_notes_notice() {
+		if ( constant_contact_get_needs_manual_reconnect() ) {
+			return '';
+		}
 		ob_start();
 		?>
 		<div class="admin-notice-message">
 			<?php
-			// Since we are keeping this permanently shown, we are removing the paragraph tag to reduce vertical space sightly.
-			esc_html_e( 'If you recently created a list in your Constant Contact Dashboard and do not see it here, please use the "Sync Lists with Constant Contact" link.', 'constant-contact-forms' );
-			echo '<br/>';
-			esc_html_e( 'Your lists should automatically sync every twelve hours.', 'constant-contact-forms' );
+			if ( ! constant_contact()->api->is_connected() ) {
+				esc_html_e( 'If you want to make use of lists, sign up for an account or connect your existing account.', 'constant-contact-forms' );
+			} else {
+				// Since we are keeping this permanently shown, we are removing the paragraph tag to reduce vertical space sightly.
+				esc_html_e( 'If you recently created a list in your Constant Contact Dashboard and do not see it here, please use the "Sync Lists with Constant Contact" link.', 'constant-contact-forms' );
+				echo '<br/>';
+				esc_html_e( 'Your lists should automatically sync every twelve hours.', 'constant-contact-forms' );
+			}
 			?>
 		</div>
 		<?php

--- a/includes/class-notification-content.php
+++ b/includes/class-notification-content.php
@@ -344,10 +344,11 @@ class ConstantContact_Notification_Content {
 		?>
 		<div class="admin-notice-message">
 			<?php
+			// Since we are keeping this permanently shown, we are removing the paragraph tag to reduce vertical space sightly.
 			if ( ! constant_contact()->api->is_connected() ) {
 				esc_html_e( 'If you want to make use of lists, sign up for an account or connect your existing account.', 'constant-contact-forms' );
 			} else {
-				// Since we are keeping this permanently shown, we are removing the paragraph tag to reduce vertical space sightly.
+
 				esc_html_e( 'If you recently created a list in your Constant Contact Dashboard and do not see it here, please use the "Sync Lists with Constant Contact" link.', 'constant-contact-forms' );
 				echo '<br/>';
 				esc_html_e( 'Your lists should automatically sync every twelve hours.', 'constant-contact-forms' );

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -70,11 +70,11 @@ class ConstantContact_Settings {
 	public function register_hooks() {
 		add_action( 'cmb2_admin_init', [ $this, 'set_metabox_titles' ] );
 		add_action( 'cmb2_admin_init', [ $this, 'add_options_page_metaboxes' ] );
+		add_action( 'cmb2_admin_init', [ $this, 'register_metabox_override_hooks' ] );
 
 		add_action( 'admin_menu', [ $this, 'remove_extra_menu_items' ], 999 );
 		add_filter( 'parent_file', [ $this, 'select_primary_menu_item' ] );
 
-		$this->register_metabox_override_hooks();
 		$this->inject_optin_form_hooks();
 
 		add_filter( 'preprocess_comment', [ $this, 'process_optin_comment_form' ] );
@@ -109,11 +109,7 @@ class ConstantContact_Settings {
 	 *
 	 * @return void
 	 */
-	protected function register_metabox_override_hooks() {
-		if ( ! is_array( $this->metabox_titles ) ) {
-			return;
-		}
-
+	public function register_metabox_override_hooks() {
 		foreach ( array_keys( $this->metabox_titles ) as $cmb_key ) {
 			add_filter( "cmb2_override_option_get_{$this->key}_{$cmb_key}", [ $this, 'get_override' ], 10, 2 );
 			add_filter( "cmb2_override_option_save_{$this->key}_{$cmb_key}", [ $this, 'update_override' ], 10, 2 );


### PR DESCRIPTION
This PR amends how we're handling lists and some list management, depending on the current state of our API access.

1. Removes need to be connected, to register the list post type. This should help ensure associated lists to forms are still available, even if the API isn't at the moment. Site visitors can still successfully submit
2. Conditionally change the "Sync lists" link based on if we need to manually connect and are connected. Non connected and no API connection issues just do not get the link shown.
3. Conditionally amend our new permanent lists admin notification content, based on connected or not. If not connected and no API issues, encourage signing up and/or connecting the user's account. If connected, retain newly merged wording about making use of the sync, and informing about 12hr auto-sync schedule.
4. Amend some settings details that were preventing successful account connections after some code edits to remove internationalization warnings.