### PR TITLE
Conditional disclaimer display

### DIFF
--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -2074,6 +2074,10 @@ class ConstantContact_Display {
 			return '';
 		}
 
+		if ( ! constant_contact()->get_api()->is_connected() ) {
+			return '';
+		}
+
 		$list = $optin['list'] ?? false;
 
 		if ( ! $list ) {


### PR DESCRIPTION
This PR prevents display of the Constant Contact disclosure text if the site is presently not connected to a Constant Contact account.

In those situations, the form becomes a basic contact form and does not send anything to Constant Contact.