### PR TITLE
properly set expected values with null coalescing operator usage. We want the lists, not its evaluation to true

### DIFF
--- a/includes/class-mail.php
+++ b/includes/class-mail.php
@@ -67,7 +67,7 @@ class ConstantContact_Mail {
 		$submission_details['form_id']         = $values['ctct-id']['value'];
 		$submission_details['submitted_email'] = $this->get_user_email_from_submission( $values );
 
-		$lists  = isset( $values['ctct-lists'] ) ?? [];
+		$lists  = $values['ctct-lists'] ?? [];
 		$values = constant_contact()->get_process_form()->pretty_values( $values );
 
 		$email_values = $this->format_values_for_email( $values, $submission_details['form_id'] );


### PR DESCRIPTION
This PR changes accidental assignment of `true` to the variable instead of the original lists content.