### PR TITLE
Feature/con 417 help page code removal

### DIFF
--- a/includes/class-admin-pages.php
+++ b/includes/class-admin-pages.php
@@ -56,145 +56,6 @@ class ConstantContact_Admin_Pages {
 	}
 
 	/**
-	 * Gets the help text for help page.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return array Array of all the help text.
-	 */
-	public function get_help_texts() {
-
-		/**
-		 * Filters our default help texts.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param array $value Array of arrays with title/content values.
-		 */
-		return apply_filters(
-			'constant_contact_help_texts',
-			[
-				[
-					'title'   => esc_html__( 'This is a sample help header', 'constant-contact-forms' ),
-					'content' => esc_html__( 'This is some sample help text.', 'constant-contact-forms' ),
-				],
-				[
-					'title'   => esc_html__( 'This is another sample header', 'constant-contact-forms' ),
-					'content' => esc_html__( 'This is also some sample help text.', 'constant-contact-forms' ),
-				],
-			]
-		);
-	}
-
-	/**
-	 * Get faq text for help page.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return array Array of all the text.
-	 */
-	public function get_faq_texts() {
-
-		/**
-		 * Filters our FAQ text for the help page.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param array $value Array of arrays for help text.
-		 */
-		return apply_filters(
-			'constant_contact_faq_texts',
-			[
-				[
-					'title'   => esc_html__( 'Is this a sample question?', 'constant-contact-forms' ),
-					'content' => esc_html__( 'This is a sample answer', 'constant-contact-forms' ),
-				],
-				[
-					'title'   => esc_html__( 'This is also a sample question', 'constant-contact-forms' ),
-					'content' => esc_html__( 'This is another sample answer', 'constant-contact-forms' ),
-				],
-			]
-		);
-	}
-
-	/**
-	 * Display our help page.
-	 *
-	 * @since 1.0.0
-	 */
-	public function help_page() {
-		?>
-		<h2>
-			<?php esc_attr_e( 'Help / FAQ', 'constant-contact-forms' ); ?>
-		</h2>
-		<div class="ctct-wrap wrap">
-			<table id="ctct-support" class="ctct-form-table">
-				<tr>
-					<td class="outer outer-first">
-						<h2>
-							<?php esc_html_e( 'Help', 'constant-contact-forms' ); ?>
-						</h2>
-						<ol id="help_ctct">
-						<?php
-						$helps = $this->get_help_texts();
-
-						if ( is_array( $helps ) ) {
-
-							foreach ( $helps as $help ) {
-								if ( ! isset( $help['title'] ) || ! isset( $help['content'] ) ) {
-									continue;
-								}
-								?>
-								<li>
-									<span class="question" aria-controls="q1" aria-expanded="false">
-										<?php echo esc_html( $help['title'] ); ?>
-									</span>
-									<div class="answer">
-										<?php echo esc_html( $help['content'] ); ?>
-									</div>
-								</li>
-								<?php
-							}
-						}
-						?>
-						</ol>
-					</td>
-					<td class="outter">
-						<h2>
-							<?php esc_html_e( 'FAQ', 'constant-contact-forms' ); ?>
-						</h2>
-						<ol id="faq_ctct">
-						<?php
-						$faqs = $this->get_faq_texts();
-
-						if ( is_array( $faqs ) ) {
-
-							foreach ( $faqs as $faq ) {
-								if ( ! isset( $faq['title'] ) || ! isset( $faq['content'] ) ) {
-									continue;
-								}
-								?>
-							<li>
-								<span class="question" aria-controls="q1" aria-expanded="false">
-									<?php echo esc_html( $faq['title'] ); ?>
-								</span>
-								<div class="answer">
-									<?php echo esc_html( $faq['content'] ); ?>
-								</div>
-							</li>
-								<?php
-							}
-						}
-						?>
-						</ol>
-					</td>
-				</tr>
-			</table>
-		</div>
-		<?php
-	}
-
-	/**
 	 * Display our about page.
 	 *
 	 * @since 1.0.0
@@ -208,14 +69,10 @@ class ConstantContact_Admin_Pages {
 			$new_link  = constant_contact()->get_api()->get_signup_link();
 			$auth_link = admin_url( 'edit.php?post_type=ctct_forms&page=ctct_options_connect' );
 		}
-
 		?>
 
-
 		<h2><?php esc_html_e( 'About Constant Contact Forms', 'constant-contact-forms' ); ?></h2>
-
 		<div class="constant-contact-about">
-
 			<div class="ctct-section section-about">
 				<p class="large-text">
 					<?php echo wp_kses_post( esc_html__( "This plugin makes it fast and easy to capture all kinds of visitor information right from your WordPress site—even if you don't have a Constant Contact account.", 'constant-contact-forms' ) ); ?>

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -293,9 +293,6 @@ class ConstantContact_Admin {
 					case 'about':
 						constant_contact()->get_admin_pages()->about_page();
 						break;
-					case 'help':
-						constant_contact()->get_admin_pages()->help_page();
-						break;
 					case 'license':
 						constant_contact()->get_admin_pages()->license_page();
 						break;

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -81,7 +81,7 @@ class ConstantContact_Admin {
 	 * @param Constant_Contact $plugin Primary class file.
 	 * @param string           $basename Primary class basename.
 	 */
-	public function __construct( $plugin, $basename ) {
+	public function __construct( Constant_Contact $plugin, string $basename ) {
 		$this->plugin   = $plugin;
 		$this->basename = $basename;
 		$this->hooks();
@@ -112,12 +112,12 @@ class ConstantContact_Admin {
 	/**
 	 * Adds functionality to Constant Contact admin screen.
 	 *
-	 * @param array $screen Details on the current admin screen.
+	 * @param WP_Screen $screen Details on the current admin screen.
 	 * @return void
 	 * @since 1.11.0
 	 * @author Darren Cooney <darren.cooney@webdevstudios.com>
 	 */
-	public function current_screen( $screen ) {
+	public function current_screen( WP_Screen $screen ) {
 		if ( constant_contact()->is_constant_contact() ) {
 			add_action( 'in_admin_header', [ $this, 'admin_page_toolbar' ] );
 		}
@@ -133,7 +133,7 @@ class ConstantContact_Admin {
 	 */
 	public function admin_page_toolbar() {
 
-		global $submenu, $submenu_file, $plugin_page, $pagenow;
+		global $submenu, $submenu_file, $plugin_page;
 
 		$cpt_slug    = 'ctct_forms';
 		$parent_slug = "edit.php?post_type=$cpt_slug";
@@ -256,7 +256,7 @@ class ConstantContact_Admin {
 		remove_submenu_page( $this->parent_menu_slug, $this->key . '_license' );
 
 		// Include CMB CSS in the head to avoid FOUC.
-		add_action( "admin_print_styles-{$this->options_page}", [ 'CMB2_hookup', 'enqueue_cmb_css' ] );
+		add_action( "admin_print_styles-$this->options_page", [ 'CMB2_hookup', 'enqueue_cmb_css' ] );
 
 	}
 
@@ -278,7 +278,6 @@ class ConstantContact_Admin {
 		<div class="wrap cmb2-options-page <?php echo esc_attr( $this->key ); ?> ctct-page-wrap">
 
 			<?php
-
 			$page = [];
 			// phpcs:disable WordPress.Security.NonceVerification -- OK accessing of $_GET values.
 			if ( isset( $_GET['page'] ) ) {
@@ -313,26 +312,6 @@ class ConstantContact_Admin {
 	}
 
 	/**
-	 * Register settings notices for display.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int   $object_id Option key.
-	 * @param array $updated   Array of updated fields.
-	 *
-	 * @return void
-	 */
-	public function settings_notices( $object_id, $updated ) {
-
-		if ( $object_id !== $this->key || empty( $updated ) ) {
-			return;
-		}
-
-		add_settings_error( $this->key . '-notices', '', esc_html__( 'Settings updated.', 'constant-contact-forms' ), 'updated' );
-		settings_errors( $this->key . '-notices' );
-	}
-
-	/**
 	 * Public getter method for retrieving protected/private variables.
 	 *
 	 * @since 1.0.0
@@ -364,7 +343,7 @@ class ConstantContact_Admin {
 	 *
 	 * @since 1.0.0
 	 */
-	public function set_custom_columns( array $columns ) {
+	public function set_custom_columns( array $columns ) : array {
 
 		$columns['description'] = esc_html__( 'Description', 'constant-contact-forms' );
 		$columns['shortcodes']  = esc_html__( 'Shortcode', 'constant-contact-forms' );
@@ -445,9 +424,9 @@ class ConstantContact_Admin {
 	 *
 	 * @param array $columns WP_List_Table columns.
 	 *
-	 * @return mixed
+	 * @return array
 	 */
-	public function set_custom_lists_columns( array $columns ) {
+	public function set_custom_lists_columns( array $columns ) : array {
 		$columns['ctct_total'] = esc_html__( 'Contact Count', 'constant-contact-forms' );
 
 		unset( $columns['date'] );
@@ -544,7 +523,7 @@ class ConstantContact_Admin {
 	 * @param string $link_slug The slug of the admin page.
 	 * @return string
 	 */
-	public function get_admin_link( $text, $link_slug ) {
+	public function get_admin_link( string $text, string $link_slug ) : string {
 
 		static $link_template = '<a title="%1$s" href="%2$s" target="_blank" rel="noopener noreferrer">%1$s</a>';
 		static $link_args     = [


### PR DESCRIPTION
This PR removes some unused methods meant for output for a Help/FAQ page that we're going to not go with.

It also does some new PHPCS cleanup for one of the files we're editing overall.