### PR TITLE
Feature/con 436 custom heading levels

### DIFF
--- a/includes/class-builder-fields.php
+++ b/includes/class-builder-fields.php
@@ -540,6 +540,27 @@ class ConstantContact_Builder_Fields {
 
 		$custom_css_metabox->add_field(
 			[
+				'name'        => esc_html__( 'Form title heading level', 'constant-contact-forms' ),
+				'id'          => $this->prefix . 'form_title_heading_level',
+				'type'        => 'select',
+				'default'     => 'h3',
+				'options'     => [
+					'h1' => esc_html__( 'H1', 'constant-contact-forms' ),
+					'h2' => esc_html__( 'H2', 'constant-contact-forms' ),
+					'h3' => esc_html__( 'H3', 'constant-contact-forms' ),
+					'h4' => esc_html__( 'H4', 'constant-contact-forms' ),
+					'h5' => esc_html__( 'H5', 'constant-contact-forms' ),
+					'h6' => esc_html__( 'H6', 'constant-contact-forms' ),
+				],
+				'description' => esc_html__(
+					'Set the heading level for the title.',
+					'constant-contact-forms'
+				),
+			]
+		);
+
+		$custom_css_metabox->add_field(
+			[
 				'name'        => esc_html__( 'Form Padding', 'constant-contact-forms' ),
 				'type'        => 'title',
 				'id'          => 'form-padding-title',

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -159,6 +159,7 @@ class ConstantContact_Display {
 			'form_submit_button_font_size'        => '',
 			'form_submit_button_text_color'       => '',
 			'form_submit_button_background_color' => '',
+			'form_title_heading_level'            => 'h3',
 			'form_padding_top'                    => '',
 			'form_padding_right'                  => '',
 			'form_padding_bottom'                 => '',
@@ -196,6 +197,11 @@ class ConstantContact_Display {
 		$ctct_form_submit_button_background_color = get_post_meta( $form_id, '_ctct_form_submit_button_background_color', true );
 		if ( ! empty( $ctct_form_submit_button_background_color ) ) {
 			$specific_form_css['form_submit_button_background_color'] = "background-color: $ctct_form_submit_button_background_color;";
+		}
+
+		$ctct_form_title_heading_level = get_post_meta( $form_id, '_ctct_form_title_heading_level', true );
+		if ( ! empty( $ctct_form_title_heading_level ) ) {
+			$specific_form_css['form_title_heading_level'] = $ctct_form_title_heading_level;
 		}
 
 		$ctct_form_padding_top = get_post_meta( $form_id, '_ctct_form_padding_top', true );
@@ -257,9 +263,16 @@ class ConstantContact_Display {
 			return '';
 		}
 
+		$heading_level = $this->specific_form_styles['form_title_heading_level'];
 		$title_styles = $this->set_title_styles();
 
-		return '<h3' . $title_styles . '>' . esc_html( get_the_title( $form_id ) ) . '</h3>';
+		return sprintf(
+			'<%1$s%2$s>%3$s</%4$s>',
+			$heading_level,
+			$title_styles,
+			esc_html( get_the_title( $form_id ) ),
+			$heading_level
+		);
 	}
 
 	/**


### PR DESCRIPTION
This PR adds a dropdown to choose the heading level for form titles. It should default to `<h3>` which is what we've been using so far, allowing for backwards compat.