### PR TITLE
Fix/con 453 disclosure data fix

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1215,7 +1215,7 @@ class ConstantContact_API {
 		 * ]
 		 */
 
-		static $address_fields = [ 'line1', 'city', 'state_code', 'postal_code' ];
+		static $address_fields = [ 'address_line1', 'address_line2', 'address_line3', 'city', 'state_code', 'postal_code' ];
 
 		// Grab disclosure info from the API.
 		$account_info = $this->get_account_info();
@@ -1235,10 +1235,10 @@ class ConstantContact_API {
 
 		// Determine the address to use for disclosure from the API.
 		if (
-			isset( $account_info->organization_addresses )
-			&& count( $account_info->organization_addresses )
+			isset( $account_info['physical_address'] )
+			&& count( $account_info['physical_address'] )
 		) {
-			$organization_address = array_shift( $account_info->organization_addresses );
+			$organization_address = $account_info['physical_address'];
 			$disclosure_address   = [];
 
 			if ( is_array( $address_fields ) ) {
@@ -1254,8 +1254,8 @@ class ConstantContact_API {
 			unset( $disclosure['address'] );
 		}
 
-		if ( ! empty( $account_info->website ) ) {
-			$disclosure['website'] = $account_info->website;
+		if ( ! empty( $account_info['website'] ) ) {
+			$disclosure['website'] = $account_info['website'];
 		}
 
 		return $as_parts ? $disclosure : implode( ', ', array_values( $disclosure ) );

--- a/includes/class-client.php
+++ b/includes/class-client.php
@@ -56,7 +56,7 @@ class ConstantContact_Client {
 	 * @return array
 	 */
 	public function get_account_info() {
-		return $this->get( 'account/summary', $this->base_args );
+		return $this->get( 'account/summary?extra_fields=physical_address', $this->base_args );
 	}
 
 	/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -471,7 +471,7 @@ class ConstantContact_Settings {
 				$disclosure_info = $this->plugin->get_api()->get_disclosure_info( true );
 				if ( ! empty( $disclosure_info ) ) {
 					$business_name = $disclosure_info['name'] ?: $business_name;
-					$business_addr = isset( $disclosure_info['address'] ) ?: '';
+					$business_addr = $disclosure_info['address'] ?: '';
 				}
 
 				$cmb->add_field(


### PR DESCRIPTION
This PR updates and fixes issues around our retrieval of account address information and "elvis" operator usage.

The incoming data from API version 3 is different from version 2, and disclosure/address data was not properly updated to match.

This includes data coming in as array once decoded, instead of an object, as well as array index keys being different.

Lastly, we needed to add an extra URL parameter to get physical address data, as it is not included by default.