### PR TITLE
Feature/con 481 assign list reminder

### DIFF
--- a/includes/class-notification-content.php
+++ b/includes/class-notification-content.php
@@ -379,7 +379,7 @@ class ConstantContact_Notification_Content {
 		?>
 		<div class="admin-notice-message">
 			<?php
-				esc_html_e( 'Do not forget to assign a list to use with the form!', 'constant-contact-forms' );
+				esc_html_e( 'No list selected. Assign a list to capture email leads.', 'constant-contact-forms' );
 			?>
 		</div>
 		<?php

--- a/includes/class-notification-content.php
+++ b/includes/class-notification-content.php
@@ -370,7 +370,7 @@ class ConstantContact_Notification_Content {
 	/**
 	 * Admin notice regarding selecting a list.
 	 *
-	 * @since NEXT
+	 * @since 2.15.0
 	 *
 	 * @return false|string
 	 */
@@ -582,7 +582,7 @@ add_filter( 'constant_contact_notifications', 'constant_contact_lists_notes_noti
 /**
  * Add notification regarding list assignment
  *
- * @since NEXT
+ * @since 2.15.0
  *
  * @param array $notifications Array of notifications to be shown.
  * @return array               Array of notifications to be shown.

--- a/includes/class-notification-content.php
+++ b/includes/class-notification-content.php
@@ -379,7 +379,7 @@ class ConstantContact_Notification_Content {
 		?>
 		<div class="admin-notice-message">
 			<?php
-				esc_html_e( 'Do not forget to asign a list to use with the form!', 'constant-contact-forms' );
+				esc_html_e( 'Do not forget to assign a list to use with the form!', 'constant-contact-forms' );
 			?>
 		</div>
 		<?php

--- a/includes/class-notification-content.php
+++ b/includes/class-notification-content.php
@@ -366,6 +366,25 @@ class ConstantContact_Notification_Content {
 		<?php
 		return ob_get_clean();
 	}
+
+	/**
+	 * Admin notice regarding selecting a list.
+	 *
+	 * @since NEXT
+	 *
+	 * @return false|string
+	 */
+	public static function list_selection_notice(): string {
+		ob_start();
+		?>
+		<div class="admin-notice-message">
+			<?php
+				esc_html_e( 'Do not forget to asign a list to use with the form!', 'constant-contact-forms' );
+			?>
+		</div>
+		<?php
+		return ob_get_clean();
+	}
 }
 
 /**
@@ -559,3 +578,24 @@ function constant_contact_lists_notes_notification( array $notifications = [] ):
 	return $notifications;
 }
 add_filter( 'constant_contact_notifications', 'constant_contact_lists_notes_notification' );
+
+/**
+ * Add notification regarding list assignment
+ *
+ * @since NEXT
+ *
+ * @param array $notifications Array of notifications to be shown.
+ * @return array               Array of notifications to be shown.
+ */
+function constant_contact_lists_selection_notification( array $notifications = [] ): array {
+	$notifications[] = [
+		'ID'           => 'list_selection_notice',
+		'callback'     => [ 'ConstantContact_Notification_Content', 'list_selection_notice' ],
+		'require_cb'   => 'constant_contact_maybe_show_lists_selection_notification',
+		'show_dismiss' => true,
+	];
+
+	return $notifications;
+}
+
+add_filter( 'constant_contact_notifications', 'constant_contact_lists_selection_notification' );

--- a/includes/notification-logic.php
+++ b/includes/notification-logic.php
@@ -267,3 +267,36 @@ function constant_contact_maybe_show_list_notes_notification(): bool {
 
 	return true;
 }
+
+/**
+ * Maybe display our list selection reminder.
+ *
+ * @since NEXT
+ *
+ * @return bool
+ */
+function constant_contact_maybe_show_lists_selection_notification(): bool {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return false;
+	}
+
+	if ( ! constant_contact()->is_constant_contact() ) {
+		return false;
+	}
+
+	if ( ! constant_contact()->get_api()->is_connected() ) {
+		return false;
+	}
+
+	if ( empty( $_GET ) ) {
+		return false;
+	}
+
+	if ( isset( $_GET['post'] ) && is_numeric( $_GET['post'] ) ) {
+		$thepostmeta = get_post_meta( absint( $_GET['post'] ) );
+
+		return empty( $thepostmeta['_ctct_list'] );
+	}
+
+	return false;
+}

--- a/includes/notification-logic.php
+++ b/includes/notification-logic.php
@@ -271,7 +271,7 @@ function constant_contact_maybe_show_list_notes_notification(): bool {
 /**
  * Maybe display our list selection reminder.
  *
- * @since NEXT
+ * @since 2.15.0
  *
  * @return bool
  */


### PR DESCRIPTION
Closes:

[https://app.clickup.com/t/9011385391/CON-481](https://app.clickup.com/t/9011385391/CON-481)

> We are pending potential discussion on wording for the admin notice, so do not worry about approving yet.

This PR adds an admin notice to our form editor screen, and will remind about adding at least one list to the form.

It is dismissable.

It won't show if a list is chosen, but will again, if all lists are removed AND it hasn't been manually dismissed.