### PR TITLE
CON-483 apply inline styles for bottom/right label placement

### DIFF
--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -1252,7 +1252,12 @@ class ConstantContact_Display {
 		$field = $markup;
 
 		if ( $show_label && ( 'bottom' === $label_placement || 'right' === $label_placement ) && ( 'submit' !== $type ) ) {
-			$markup .= '<span class="' . $label_placement_class . '">';
+			if ( $inline_font_styles ) {
+				$markup .= '<span class="' . $label_placement_class . '"  style="' . $inline_font_styles . '">';
+			} else {
+				$markup .= '<span class="' . $label_placement_class . '">';
+			}
+
 			$markup .= $this->get_label( $field_id, $name . ' ' . $req_label );
 			$markup .= '</span>';
 		}


### PR DESCRIPTION
Closes https://app.clickup.com/t/9011385391/CON-483

This PR adds output for inline font styles for bottom/right positioned labels to match top/left positioning.