### PR TITLE
Fix/con 494 composer compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 .gitmodules
 plugin-config.js
 
+/bin
+
 # Logs
 /logs
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ plugin-config.js
 
 # Composer
 /vendor
+/vendor_prefixed
 
 ### Xcode ###
 

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,23 @@
       }
    ],
    "extra":{
-      "phpcodesniffer-search-depth":5
+      "phpcodesniffer-search-depth":5,
+      "strauss": {
+      "target_directory": "vendor_prefixed",
+      "namespace_prefix": "ConstantContact\\ConstantContactForms\\",
+      "packages": [
+        "defuse/php-encryption",
+        "google/recaptcha",
+        "psr/log",
+        "monolog/monolog"
+      ],
+      "delete_vendor_files": false
+    }
    },
    "scripts":{
       "dist":[
          "rm -rf ./vendor",
+         "rm -rf ./vendor_prefixed",
          "npm install",
          "npm run build:release",
          "rm -rf ./.git",
@@ -63,6 +75,7 @@
          "rm -rf ./tests",
          "rm -rf ./webpack.config.js",
          "@composer install --no-dev -a",
+         "@composer run prefix-namespaces",
          "@composer archive --format=zip --file constant-contact-forms",
          "rm -rf ./composer.json",
          "rm -rf ./composer.lock",
@@ -77,6 +90,11 @@
       ],
       "post-update-cmd":[
          "@install-codestandards"
+      ],
+      "prefix-namespaces": [
+        "sh -c 'test -f ./bin/strauss.phar || curl -o bin/strauss.phar -L -C - https://github.com/BrianHenryIE/strauss/releases/latest/download/strauss.phar'",
+        "@php bin/strauss.phar",
+        "@composer dump-autoload"
       ]
    },
    "config": {

--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -560,7 +560,7 @@ class Constant_Contact {
 	public function load_libs() {
 
 		// Load what we can, automagically.
-		require_once $this->dir( 'vendor/autoload.php' );
+		require_once $this->dir( 'vendor_prefixed/autoload.php' );
 
 		require_once $this->dir( 'vendor/cmb2/cmb2/init.php' );
 	}

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -9,8 +9,8 @@
  *
  * phpcs:disable WebDevStudios.All.RequireAuthor -- Don't require author tag in docblocks.
  */
-use Defuse\Crypto\Key;
-use Defuse\Crypto\Crypto;
+use ConstantContact\ConstantContactForms\Defuse\Crypto\Key;
+use ConstantContact\ConstantContactForms\Defuse\Crypto\Crypto;
 
 /**
  * Powers our admin connect page, as well as misc functionality around connecting to Constant Contact.

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -10,8 +10,8 @@
  * phpcs:disable WebDevStudios.All.RequireAuthor -- Don't require author tag in docblocks.
  */
 
-use \ReCaptcha\ReCaptcha;
-use \ReCaptcha\RequestMethod\CurlPost;
+use ConstantContact\ConstantContactForms\ReCaptcha\ReCaptcha;
+use ConstantContact\ConstantContactForms\ReCaptcha\RequestMethod\CurlPost;
 use Ctct\Exceptions\CtctException;
 /**
  * Powers our form processing, validation, and value cleanup.

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -10,7 +10,7 @@
  */
 
 // phpcs:disable PEAR.NamingConventions.ValidClassName.Invalid -- OK classname.
-use ReCaptcha\ReCaptcha;
+use ConstantContact\ConstantContactForms\ReCaptcha\ReCaptcha as ReCaptcha;
 
 /**
  * Class ConstantContact_reCAPTCHA.

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -9,9 +9,9 @@
  * phpcs:disable WebDevStudios.All.RequireAuthor -- Don't require author tag in docblocks.
  */
 
-use Monolog\Formatter\LineFormatter;
-use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
+use ConstantContact\ConstantContactForms\Monolog\Formatter\LineFormatter;
+use ConstantContact\ConstantContactForms\Monolog\Logger;
+use ConstantContact\ConstantContactForms\Monolog\Handler\StreamHandler;
 
 /**
  * Checks to see if a user is connected to Constant Contact or not.


### PR DESCRIPTION
This PR makes use of [https://github.com/brianhenryie/strauss](https://github.com/brianhenryie/strauss) to automatically namespace Composer libraries to a namespace of our own.

It also updates our locations of using the libraries to point to correct namespaces so that there are no PHP fatal errors.