### PR TITLE
Release 2.15.2

### DIFF
--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -12,7 +12,7 @@
  * Plugin Name: Constant Contact Forms for WordPress
  * Plugin URI:  https://www.constantcontact.com
  * Description: Be a better marketer. All it takes is Constant Contact email marketing.
- * Version:     2.15.1
+ * Version:     2.15.2
  * Author:      Constant Contact
  * Author URI:  https://www.constantcontact.com/index?pn=miwordpress
  * Requires PHP: 8.1
@@ -75,7 +75,7 @@ class Constant_Contact {
 	 * @since 1.0.0
 	 * @var string
 	 */
-	const VERSION = '2.15.1';
+	const VERSION = '2.15.2';
 
 	/**
 	 * URL of plugin directory.

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1684,7 +1684,7 @@ class ConstantContact_API {
 			$expires_in = $this->expires_in;
 		}
 		$current_time = time();
-		$expiration_time = $issued_time + $expires_in;
+		$expiration_time = (int) $issued_time + (int) $expires_in;
 
 		// If we're currently above the expiration time, we're expired.
 		return $current_time >= $expiration_time;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "constant-contact-forms",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "constant-contact-forms",
-      "version": "2.15.1",
+      "version": "2.15.2",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@wordpress/prettier-config": "^4.36.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constant-contact-forms",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "description": "",
   "main": "build/index.js",
   "engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      constantcontact, webdevstudios, tw2113, znowebdev, ggwicz, ra
 Tags: constant contact, constant contact official, marketing, newsletter, contacts
 Requires at least: 6.4.0
 Tested up to:      6.9
-Stable tag:        2.15.1
+Stable tag:        2.15.2
 License:           GPLv3
 License URI:       http://www.gnu.org/licenses/gpl-3.0.html
 Requires PHP:      8.1
@@ -48,6 +48,9 @@ Development of Constant Contact Forms plugin occurs on [GitHub](https://github.c
 5. Basic Form
 
 == Changelog ==
+
+= 2.15.2 =
+* Fixed: Fatal errors regarding strings and addition vs concatenation.
 
 = 2.15.1 =
 * Fixed: Compatibility issues around Monolog logger and other plugins using different versions.


### PR DESCRIPTION
This PR addresses fatal errors from trying to add numeral strings vs concatenation. We should have been casting from the start since `current_time()` returns integers anyway.