### PR TITLE
Syncronize and fix up language rendering for CAPTCHA solutions.

### DIFF
--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -100,7 +100,6 @@ class ConstantContact_Display {
 				$recaptcha->enqueue_scripts();
 			} elseif ( 'hcaptcha' === $captcha_service->get_selected_captcha_service() ) {
 				$hcaptcha = new ConstantContact_hCaptcha();
-				$hcaptcha->set_language( apply_filters( 'constant_contact_recaptcha_lang', 'en' ) );
 				$hcaptcha->enqueue_scripts();
 			} elseif ( 'turnstile' === $captcha_service->get_selected_captcha_service() ) {
 				$turnstile = new ConstantContact_turnstile();

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -86,15 +86,17 @@ class ConstantContact_Display {
 
 				/**
 				 * Filters the language code to be used with Google reCAPTCHA.
+				 *
 				 * See https://developers.google.com/recaptcha/docs/language for available values.
 				 *
 				 * @since 1.2.4
 				 * @since 1.7.0  Added form ID for conditional amending.
 				 * @since 2.10.0 Removed form ID due to changing where we invoke and use language code.
+				 * @since 2.16.0 Removed forced use of English, allowing for Google to autodetect.
 				 *
-				 * @param string $value Language code to use. Default 'en'.
+				 * @param string $value Language code to use. Default '' (makes Google autodetect).
 				 */
-				$recaptcha->set_language( apply_filters( 'constant_contact_recaptcha_lang', 'en' ) );
+				$recaptcha->set_language( apply_filters( 'constant_contact_recaptcha_lang', '' ) );
 				$recaptcha->enqueue_scripts();
 			} elseif ( 'hcaptcha' === $captcha_service->get_selected_captcha_service() ) {
 				$hcaptcha = new ConstantContact_hCaptcha();

--- a/includes/class-hcaptcha.php
+++ b/includes/class-hcaptcha.php
@@ -223,14 +223,19 @@ class ConstantContact_hCaptcha {
 			true
 		);
 
+		$query_args = [
+			'onload' => 'renderhCaptcha',
+			'render' => 'explicit',
+		];
+		$lang = $this->get_language();
+		if ( ! empty( $lang ) ) {
+			$query_args['hl'] = $lang;
+		}
+
 		wp_enqueue_script(
 			'hcaptcha-api',
 			add_query_arg(
-				[
-					'hl'     => $this->get_language(),
-					'onload' => 'renderhCaptcha',
-					'render' => 'explicit',
-				],
+				$query_args,
 				'https://js.hcaptcha.com/1/api.js'
 			),
 			[ 'hcaptcha' ],

--- a/includes/class-recaptcha-v2.php
+++ b/includes/class-recaptcha-v2.php
@@ -45,14 +45,19 @@ class ConstantContact_reCAPTCHA_v2 extends ConstantContact_reCAPTCHA {
 			true
 		);
 
+		$query_args = [
+			'onload' => 'renderReCaptcha',
+			'render' => 'explicit',
+		];
+		$lang       = $this->get_language();
+		if ( ! empty( $lang ) ) {
+			$query_args['hl'] = $lang;
+		}
+
 		wp_enqueue_script(
 			'recaptcha-lib-v2',
 			add_query_arg(
-				[
-					'hl'     => $this->get_language(),
-					'onload' => 'renderReCaptcha',
-					'render' => 'explicit',
-				],
+				$query_args,
 				'//www.google.com/recaptcha/api.js'
 			),
 			[ 'recaptcha-v2' ],

--- a/includes/class-turnstile.php
+++ b/includes/class-turnstile.php
@@ -254,10 +254,12 @@ class ConstantContact_turnstile {
 				data-size="%3$s"
 				data-callback="ctctTurnstileEnableBtn"
 				data-expired-callback="ctctTurnstileDisableBtn"
+				data-language="%4$s"
 			></div>',
 			esc_attr( $this->site_key ),
 			esc_attr( $this->get_theme() ),
-			esc_attr( $this->get_size() )
+			esc_attr( $this->get_size() ),
+			esc_attr( $this->get_language() )
 		);
 	}
 


### PR DESCRIPTION
This PR does the following:

1. Undoes forced english by default for Google reCAPTCHA.
2. Adds language support to Turnstile
3. Conditionally passes reCAPTCHA and hCAPTCHA language parameters if we have any set. Otherwise default to auto-detect.