### PR TITLE
Feature/con 499 api updates

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1431,6 +1431,10 @@ class ConstantContact_API {
 	 */
 	public function acquire_access_token(): bool {
 
+		if ( ! empty( $_POST['action'] ) && 'heartbeat' === sanitize_text_field( $_POST['action'] ) ) {
+			return false;
+		}
+
 		$code_state = (string) constant_contact_get_option( '_ctct_form_state_authcode', '' );
 
 		parse_str( $code_state, $parsed_code_state );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -247,6 +247,8 @@ class ConstantContact_API {
 			$token = constant_contact()->get_connect()->e_get( '_ctct_access_token' );
 		}
 
+		// We are accepting that we may still have "one hour" of potential valid access token time.
+		// We would rather refresh early than risk getting expired.
 		$issued_time = (int) get_option( 'ctct_access_token_timestamp', 0 );
 		$current     = time();
 		$threshold   = $current - $issued_time;

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -175,6 +175,11 @@ class ConstantContact_API {
 	 */
 	public function ctct_init() {
 
+		// Early exit for heartbeat API.
+		if ( ! empty( $_POST['action'] ) && 'heartbeat' === sanitize_text_field( $_POST['action'] ) ) {
+			return false;
+		}
+
 		$this->this_user_id = get_current_user_id();
 
 		$this->expires_in    = constant_contact()->get_connect()->e_get( '_ctct_expires_in' );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -242,17 +242,30 @@ class ConstantContact_API {
 	public function get_api_token() {
 		$token = '';
 
+		// Fetch current access token, expired or not.
 		if ( constant_contact()->get_connect()->e_get( '_ctct_access_token' ) ) {
 			$token = constant_contact()->get_connect()->e_get( '_ctct_access_token' );
 		}
 
-		$issued_time = (int) get_option( 'ctct_access_token_timestamp', '' );
+		$issued_time = (int) get_option( 'ctct_access_token_timestamp', 0 );
 		$current     = time();
-		$threshold = $current - $issued_time;
-		if ( $threshold >= 82800 && $threshold <= 86400 ) {
-			$this->refresh_token();
+		$threshold   = $current - $issued_time;
+		// Check if we should attempt a refresh, beyond just cron checks.
+		if ( $issued_time > 0 && $threshold >= 82800 && $threshold <= 86400 ) {
+			// This should not be reached constantly. Once we have a new token,
+			// the threshold won't be within time.
+			// This method is more readily called than potential cron requests, so
+			// hopefully we're more actively refreshed.
+			$result = $this->refresh_token();
 
-			$token = constant_contact()->get_connect()->e_get( '_ctct_access_token' );
+			if ( ! $result ) {
+				constant_contact_maybe_log_it( 'API', 'Refresh token attempt failed in get_api_token.' );
+				$token = ''; // Reset to default from this method.
+			}
+
+			if ( $result ) {
+				$token = constant_contact()->get_connect()->e_get( '_ctct_access_token' );
+			}
 		}
 
 		return $token;

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -198,6 +198,10 @@ class ConstantContact_API {
 			}
 		}
 
+		// Future API work. Perhaps a `$this->access_token_maybe_expired()` check here.
+		// Keep frequency of `init` hook in mind.
+		// Would also remove need to check for DISABLE_WP_CRON later.
+
 		// custom scheduling based on the expiry time returned with access token.
 		add_filter(
 			'cron_schedules',

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1697,13 +1697,8 @@ class ConstantContact_API {
 			return false;
 		}
 
-		$expires_in = constant_contact()->get_connect()->e_get( '_ctct_expires_in' );
-		if ( ! empty( $this->expires_in ) ) {
-			// Prioritize our property over the option. If this is set, it's probably fresher.
-			$expires_in = $this->expires_in;
-		}
 		$current_time = time();
-		$expiration_time = (int) $issued_time + (int) $expires_in;
+		$expiration_time = (int) $issued_time + (int) $this->expires_in;
 
 		// If we're currently above the expiration time, we're expired.
 		return $current_time >= $expiration_time;

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -240,16 +240,19 @@ class ConstantContact_API {
 	 * @return string Access API token.
 	 */
 	public function get_api_token() {
-
 		$token = '';
 
 		if ( constant_contact()->get_connect()->e_get( '_ctct_access_token' ) ) {
-			$token .= constant_contact()->get_connect()->e_get( '_ctct_access_token' );
-		} else {
-			$success = $this->acquire_access_token();
-			if ( $success ) {
-				update_option( 'ctct_access_token_timestamp', time() );
-			}
+			$token = constant_contact()->get_connect()->e_get( '_ctct_access_token' );
+		}
+
+		$issued_time = (int) get_option( 'ctct_access_token_timestamp', '' );
+		$current     = time();
+		$threshold = $current - $issued_time;
+		if ( $threshold >= 82800 && $threshold <= 86400 ) {
+			$this->refresh_token();
+
+			$token = constant_contact()->get_connect()->e_get( '_ctct_access_token' );
 		}
 
 		return $token;

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1170,15 +1170,6 @@ class ConstantContact_API {
 	}
 
 	/**
-	 * Rate limit ourselves to not bust API call rate limit.
-	 *
-	 * @since 1.0.0
-	 */
-	public function pause_api_calls() {
-		sleep( 1 );
-	}
-
-	/**
 	 * Make sure we don't over-do API requests, helper method to check if we're connected.
 	 *
 	 * @since 1.0.0

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -186,7 +186,10 @@ class ConstantContact_API {
 		if (
 			empty( $this->refresh_token ) ||
 			empty( $this->access_token )
-		) {
+		) { //POST action=ctct_options_settings_auth
+			//POST ctct-disconnect=true
+			//REQUEST: settings-updated=true
+			//doing cron check? since we have a dedicated cron callback.
 			$success = $this->acquire_access_token();
 			if ( $success ) {
 				update_option( 'ctct_access_token_timestamp', time() );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1692,7 +1692,9 @@ class ConstantContact_API {
 
 		$issued_time = get_option( 'ctct_access_token_timestamp', '' );
 		if ( empty( $issued_time ) ) {
-			return true;
+			// It's not expired because it doesn't exist.
+			// This should be filled in by now though.
+			return false;
 		}
 
 		$expires_in = constant_contact()->get_connect()->e_get( '_ctct_expires_in' );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -184,7 +184,6 @@ class ConstantContact_API {
 		// Attempt to acquire access token if we don't have it already.
 		// This fixes an issue where authorization does not work sometimes when switching between different accounts.
 		if (
-			empty( $this->expires_in ) ||
 			empty( $this->refresh_token ) ||
 			empty( $this->access_token )
 		) {

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -262,7 +262,7 @@ class ConstantContact_API {
 		$current     = time();
 		$threshold   = $current - $issued_time;
 		// Check if we should attempt a refresh, beyond just cron checks.
-		if ( $issued_time > 0 && $threshold >= 82800 && $threshold <= 86400 ) {
+		if ( $issued_time > 0 && $threshold >= 82800 ) {
 			// This should not be reached constantly. Once we have a new token,
 			// the threshold won't be within time.
 			// This method is more readily called than potential cron requests, so

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -164,7 +164,7 @@ class ConstantContact_API {
 		$this->plugin = $plugin;
 		$this->scopes = array_flip( $this->valid_scopes );
 
-		add_action( 'cmb2_init', [ $this, 'cct_init' ] );
+		add_action( 'cmb2_init', [ $this, 'ctct_init' ] );
 		add_action( 'ctct_refresh_token_job', [ $this, 'refresh_token' ] );
 		add_action( 'ctct_access_token_acquired', [ $this, 'clear_missed_api_requests' ] );
 	}
@@ -173,7 +173,7 @@ class ConstantContact_API {
 	 *
 	 * @since 1.0.0
 	 */
-	public function cct_init() {
+	public function ctct_init() {
 
 		$this->this_user_id = get_current_user_id();
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1435,6 +1435,10 @@ class ConstantContact_API {
 			return false;
 		}
 
+		if ( ! empty( $_POST['ctct-disconnect'] ) && 'true' === sanitize_text_field( $_POST['ctct-disconnect'] ) ) {
+			return false;
+		}
+
 		$code_state = (string) constant_contact_get_option( '_ctct_form_state_authcode', '' );
 
 		parse_str( $code_state, $parsed_code_state );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -186,10 +186,7 @@ class ConstantContact_API {
 		if (
 			empty( $this->refresh_token ) ||
 			empty( $this->access_token )
-		) { //POST action=ctct_options_settings_auth
-			//POST ctct-disconnect=true
-			//REQUEST: settings-updated=true
-			//doing cron check? since we have a dedicated cron callback.
+		) {
 			$success = $this->acquire_access_token();
 			if ( $success ) {
 				update_option( 'ctct_access_token_timestamp', time() );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -344,11 +344,11 @@ class ConstantContact_API {
 
 		if ( false === $contacts ) {
 			try {
-				$contacts = $this->cc()->get_contacts( $this->get_api_token() );
+				$contacts = $this->cc()->get_contacts();
 				if ( array_key_exists( 'error_key', $contacts ) && 'unauthorized' === $contacts['error_key'] ) {
 					$this->refresh_token();
 
-					$contacts = $this->cc()->get_contacts( $this->get_api_token() );
+					$contacts = $this->cc()->get_contacts();
 				}
 
 				set_transient( 'ctct_contact', $contacts, 1 * DAY_IN_SECONDS );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -164,7 +164,7 @@ class ConstantContact_API {
 		$this->plugin = $plugin;
 		$this->scopes = array_flip( $this->valid_scopes );
 
-		add_action( 'init', [ $this, 'cct_init' ] );
+		add_action( 'cmb2_init', [ $this, 'cct_init' ] );
 		add_action( 'ctct_refresh_token_job', [ $this, 'refresh_token' ] );
 		add_action( 'ctct_access_token_acquired', [ $this, 'clear_missed_api_requests' ] );
 	}

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -264,6 +264,7 @@ class ConstantContact_API {
 			}
 
 			if ( $result ) {
+				// Should be new access token.
 				$token = constant_contact()->get_connect()->e_get( '_ctct_access_token' );
 			}
 		}

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -453,6 +453,8 @@ class ConstantContact_Connect {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @TODO Remove. Unused.
+	 *
 	 * @throws Exception Exception.
 	 *
 	 * @param string $access_token API access token.

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -124,7 +124,7 @@ class ConstantContact_Connect {
 		}
 
 		if ( constant_contact_get_needs_manual_reconnect() ) {
-			$connect_title .= '<span class="dashicons dashicons-warning ctct-menu-icon"></span>';
+			$connect_title = esc_html__( 'Disconnected', 'constant-contact-forms' ) . '<span class="dashicons dashicons-warning ctct-menu-icon"></span>';
 		}
 
 		$this->options_page = add_submenu_page(

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -467,6 +467,8 @@ class ConstantContact_Connect {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @TODO Remove. Unused.
+	 *
 	 * @throws Exception Throws Exception if encountered while attempting to save API token.
 	 *
 	 * @return string Token.
@@ -479,6 +481,8 @@ class ConstantContact_Connect {
 
 	/**
 	 * If we have a legacy token, let's re-save it.
+	 *
+	 * @TODO Remove. Unused.
 	 *
 	 * @since 1.0.0
 	 */

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -77,7 +77,7 @@ class ConstantContact_Connect {
 	 * @since 1.0.0
 	 */
 	public function hooks() {
-		add_action( 'init', [ $this, 'maybe_connect' ] );
+		add_action( 'cmb2_init', [ $this, 'maybe_connect' ] );
 		add_action( 'plugins_loaded', [ $this, 'maybe_disconnect' ] );
 		add_action( 'admin_menu', [ $this, 'add_options_page' ] );
 	}


### PR DESCRIPTION
This PR handles changes to our API Processing.

## 1. Moves from `init` to `cmb2_init`

The `acquire_access_token()` method relies on CMB2-provided functions. We were potentially running our code before CMB2 helper functions were getting loaded, causing issue with our code.

The `cmb2_init` is run on `init`, but after loading of its code, so we now run just slightly later than we had been.

## 2. Amends `get_api_token()` to refresh more readily.

With this section, we remove a second call to `$this->acquire_access_token();`. It's possible this call was causing some of our successful token generation missing from change `#1` with the helper functions. This was probably getting called AFTER all of CMB2 had been loaded. However, with `#1` moving, it's no longer needed here.

We also determine a threshold for when to refresh the token, regardless of expired or not status. this will be within 1hr. This slightly bypasses the cron job. If this proves more effective, the cron scheduling could be removed in the future.

## 3. Adds some early returns for some requests

In the `ctct_init()` method, if a current request is from the Heartbeat API, just exit out. Not a cadence we want to be potentially checking things on.

In the `acquire_access_token()` method, exit early if we're in a Heartbeat API request OR we're intentionally trying to disconnect. No need to try to acquire brand new access token at those times.

## 4. Nitpicky details
1. Doesn't check if `expires_in` property is empty before trying to acquire access token. Unneeded.
2. Renames our `cct_init` to `ctct_init` for consistency.
3. Removes some api token passing to methods that don't accept just an API token.
4. Cleans up an unused `pause_api_calls()` method.
5. Amend `access_token_maybe_expired()` logic to remove unneeded code due to matching results.
6. Updated wording to "Disconnected" in the admin menu if we're likely disconnected. This is as opposed to "Disconnect" meant to indicate that's the menu you use to manually disconnect.