### PR TITLE
Feature/con 493 readme cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,45 @@
+= 2.16.0 =
+
+* Added: Cloudflare Turnstile support
+* Fixed: PHP warnings about name values from connected Constant Contact account.
+* Updated: Revised API refresh token process to try and take a more active approach instead of just WP Cron based.
+* Updated: Logging messages and data for troubleshooting API issues.
+* Updated: Default language values for CAPTCHA services. Let the service autodetect instead of force English.
+* Updated: Moved messaging about DISABLE_WP_CRON out of a notification and into Constant Contact Forms area top bar.
+
+= 2.15.2 =
+
+* Fixed: Fatal errors regarding strings and addition vs concatenation.
+
+= 2.15.1 =
+
+* Fixed: Compatibility issues around Monolog logger and other plugins using different versions.
+* Fixed: PHP notice around custom fields if not managing to connect.
+* Fixed: CMB2 Attached Post potential conflict with other plugins.
+* Updated: aria-label wording for better compliance.
+
+= 2.15.0 =
+
+* Added: Moves PHP minimum requirement to version 8.1 or higher.
+* Added: Anniversary and birthday form fields.
+* Added: Max length limit to Form builder and our custom field inputs.
+* Added: List display of existing custom fields from your Constant Contact Accout at bottom of form builder.
+* Added: Reminder to set a list for a form, when connected.
+* Fixed: Label style application for some positions.
+* Updated: Adjusted logic regarding version 2.0.0 "major upgrade" admin notification.
+* Updated: Show messaging in "Opt in" setting tab when not connected.
+* Updated: Log library version.
+* Updated: Improved log timestamp formats to make more visual sense.
+* Updated: Removed internationalization files to rely on wordpress.org translations.
+
+= 2.14.2 =
+
+* Fixed: errors regarding Google reCAPTCHA v3 javascript variables.
+
+= 2.14.1 =
+
+* Fixed: Dashicon getting escaped instead of displaying, in custom menu spot.
+
 = 2.14.0 =
 
 * Fixed: Issues with Google reCAPTCHA version 3 and forms submitted without page refresh.

--- a/readme.txt
+++ b/readme.txt
@@ -109,42 +109,6 @@ Development of Constant Contact Forms plugin occurs on [GitHub](https://github.c
 * Added: Dedicated color picker for form title display.
 * Added: Ability to display form horizontally when using just the email field.
 
-= 2.12.0 =
-* Fixed: Fatal errors around list creation within WordPress dashboard.
-* Fixed: Touchups and style bugs around Forms block.
-* Fixed: Require list selection if site has a connected account but no list is chosen for form.
-* Added: Ability to select the heading level when showing form title.
-* Updated: Touched up styles and wording in form editor.
-* Updated: Adjusted Google reCAPTCHA version 3 token timing. Assigned upon submit instead of pageload, to help avoid 2 minute expiration issues.
-
-= 2.11.3 =
-* Fixed: Email notifications being sent even when toggled off.
-* Updated: Wording in various metaboxes and some fuzzy/blurry icons.
-
-= 2.11.2 =
-* Fixed: PHP errors regarding passed variable types expecting array but getting string
-* Fixed: Checkbox widths with TwentyTwentyOne theme.
-
-= 2.11.1 =
-* Updated: restored missed php file that was causing fatal errors.
-
-= 2.11.0 =
-* Added: hCaptcha data to Site Health Panel
-* Updated: Lots of internal code cleanup
-* Updated: Removed old Constant Contact SDK code.
-* Updated: Hide disclosure text below form if not connected to Constant Contact.
-* Updated: Internal, switch to wp_admin_notice() usage.
-
-= 2.10.0 =
-* Added: Use current displayed language with Google reCAPTCHA when using WPML or PolyLang.
-* Fixed: Issues around language specifications for Google reCAPTCHA.
-* Fixed: WordPress notices around textdomain loading.
-* Fixed: Added aria-label to disclosure external links for better ADA compliance
-* Updated: Amended processes regarding failing API communications when human intervention needed. Includes preventing excessive attempts to refresh tokens in states where the attempt will fail.
-* Updated: Increased notification chances if human intervention needed.
-* Updated: Register list post type for Constant Contact Lists even if not yet connected.
-* Updated: Notice regarding list management details.
-
 == Upgrade Notice ==
 * Authentication process edits after 2.16.0 release.
 

--- a/readme.txt
+++ b/readme.txt
@@ -12,9 +12,7 @@ The official Constant Contact plugin adds a contact form to your WordPress site 
 
 == Description ==
 
-Please note: Version 2.0.0 of this plugin is a significant release, including both security and feature updates. After updating to version 2.0.0, you will be required to reconnect the plugin to your Constant Contact account & reselect the lists associated with your forms.
-
-##Work smarter, not harder. The Constant Contact Way
+## Work smarter, not harder. The Constant Contact Way
 Create branded emails, build a website, sell online, and make it easy for people to find you—all from one place.
 
 https://www.youtube.com/watch?v=Qqb0_zcRKnM
@@ -138,5 +136,8 @@ You can add this to your active theme or custom plugin: `add_filter( 'constant_c
 #### Which account level access is needed to connect my WordPress account to Constant Contact?
 You will need to make the connection to Constant Contact using the credentials of the account owner. Campaign manager credentials will not have enough access.
 
-### Error: Please select at least one list to subscribe to.
+#### Error: Please select at least one list to subscribe to.
 Some users are experiencing errors when upgrading from an older version of the plugin. If you are receiving an error "Please select at least one list to subscribe to" on your form submissions we recommend "Sync Lists with Constant Contact", this can be found in your admin dashboard Contact Form > Lists. If problem still persists we recommend recreating the form from scratch.
+
+#### Version 2.0.x
+Version 2.0.0 of this plugin is a significant release, including both security and feature updates. After updating to version 2.0.0, you will be required to reconnect the plugin to your Constant Contact account & reselect the lists associated with your forms.


### PR DESCRIPTION
This PR reorganizes and cleans up the readme.txt file.

1. Move the 2.0.0 notice at the top of the file down to the FAQ
2. Move some older changelog items over to the CHANGELOG.md file and out of readme.txt