### PR TITLE
Release2161

### DIFF
--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -12,7 +12,7 @@
  * Plugin Name: Constant Contact Forms for WordPress
  * Plugin URI:  https://www.constantcontact.com
  * Description: Be a better marketer. All it takes is Constant Contact email marketing.
- * Version:     2.16.0
+ * Version:     2.16.1
  * Author:      Constant Contact
  * Author URI:  https://www.constantcontact.com/index?pn=miwordpress
  * Requires PHP: 8.1
@@ -75,7 +75,7 @@ class Constant_Contact {
 	 * @since 1.0.0
 	 * @var string
 	 */
-	const VERSION = '2.16.0';
+	const VERSION = '2.16.1';
 
 	/**
 	 * URL of plugin directory.

--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -498,6 +498,7 @@ class Constant_Contact {
 		delete_option( 'CtctConstantContactState' );
 		delete_option( 'ctct_auth_url' );
 		delete_option( 'ctct_key' );
+		delete_option( 'ctct_maybe_needs_reconnected' );
 		constant_contact_delete_option( '_ctct_form_state_authcode' );
 		wp_clear_scheduled_hook( 'refresh_token_job' );
 		wp_unschedule_hook( 'refresh_token_job' );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -271,12 +271,12 @@ class ConstantContact_API {
 			// hopefully we're more actively refreshed.
 			$result = $this->refresh_token();
 
-			if ( ! $result ) {
+			if ( ! $result['success'] && $result['reason'] === 'expired' ) {
 				constant_contact_maybe_log_it( 'API', 'Refresh token attempt failed in get_api_token.' );
 				$token = ''; // Reset to default from this method.
 			}
 
-			if ( $result ) {
+			if ( $result['success'] ) {
 				// Should be new access token.
 				$token = constant_contact()->get_connect()->e_get( '_ctct_access_token' );
 			}
@@ -1506,14 +1506,25 @@ class ConstantContact_API {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @return bool
+	 * @return array
 	 * @throws Exception
 	 */
-	public function refresh_token(): bool {
+	public function refresh_token() {
 
+		$status = [];
 		// Force prevent any further attempts until humans interject.
 		if ( constant_contact_get_needs_manual_reconnect() ) {
-			return false;
+			$status['success'] = false;
+			$status['reason']  = 'manual_reconnect';
+
+			return $status;
+		}
+
+		$token = constant_contact()->get_connect()->e_get( '_ctct_refresh_token' );
+		if ( empty( $token ) ) {
+			$status['success'] = false;
+			$status['reason']  = 'no available token';
+			return $status;
 		}
 
 		constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh token triggered' );
@@ -1539,13 +1550,18 @@ class ConstantContact_API {
 		if ( false === $result ) {
 			constant_contact_maybe_log_it( 'Refresh Token:', 'Expired. Refresh attempted at ' . current_datetime()->format( 'Y-n-d, H:i' ) );
 			constant_contact_set_needs_manual_reconnect( 'true' );
+			$status['success'] = false;
+			$status['reason']  = 'expired';
 		} else {
 			delete_transient( 'ctct_lists' );
 			update_option( 'ctct_access_token_timestamp', time() );
 			constant_contact_set_needs_manual_reconnect( 'false' );
+
+			$status['success'] = true;
+			$status['reason']  = 'refreshed';
 		}
 
-		return $result;
+		return $status;
 	}
 
 	/**

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -164,7 +164,7 @@ class ConstantContact_API {
 		$this->plugin = $plugin;
 		$this->scopes = array_flip( $this->valid_scopes );
 
-		add_action( 'cmb2_init', [ $this, 'ctct_init' ] );
+		add_action( 'init', [ $this, 'ctct_init' ] );
 		add_action( 'ctct_refresh_token_job', [ $this, 'refresh_token' ] );
 		add_action( 'ctct_access_token_acquired', [ $this, 'clear_missed_api_requests' ] );
 	}
@@ -1437,8 +1437,8 @@ class ConstantContact_API {
 		if ( ! empty( $_POST['ctct-disconnect'] ) && 'true' === sanitize_text_field( $_POST['ctct-disconnect'] ) ) {
 			return false;
 		}
-
-		$code_state = (string) constant_contact_get_option( '_ctct_form_state_authcode', '' );
+		$options = get_option('ctct_options_settings');
+		$code_state = $options['_ctct_form_state_authcode'];
 
 		parse_str( $code_state, $parsed_code_state );
 		$parsed_code_state = array_values( $parsed_code_state );

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -77,7 +77,7 @@ class ConstantContact_Connect {
 	 * @since 1.0.0
 	 */
 	public function hooks() {
-		add_action( 'cmb2_init', [ $this, 'maybe_connect' ] );
+		add_action( 'init', [ $this, 'maybe_connect' ] );
 		add_action( 'plugins_loaded', [ $this, 'maybe_disconnect' ] );
 		add_action( 'admin_menu', [ $this, 'add_options_page' ] );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      constantcontact, webdevstudios, tw2113, znowebdev, ggwicz, ra
 Tags: constant contact, constant contact official, marketing, newsletter, contacts
 Requires at least: 6.4.0
 Tested up to:      6.9
-Stable tag:        2.16.0
+Stable tag:        2.16.1
 License:           GPLv3
 License URI:       http://www.gnu.org/licenses/gpl-3.0.html
 Requires PHP:      8.1

--- a/readme.txt
+++ b/readme.txt
@@ -49,6 +49,11 @@ Development of Constant Contact Forms plugin occurs on [GitHub](https://github.c
 
 == Changelog ==
 
+= 2.16.1 =
+* Updated: Amended some approaches in authentication process after previous release caused issues.
+* Updated: return values for more precise troubleshooting
+* Updated: delete code flag for manual reconnection on plugin deactivation.
+
 = 2.16.0 =
 * Added: Cloudflare Turnstile support
 * Fixed: PHP warnings about name values from connected Constant Contact account.
@@ -141,7 +146,7 @@ Development of Constant Contact Forms plugin occurs on [GitHub](https://github.c
 * Updated: Notice regarding list management details.
 
 == Upgrade Notice ==
-* Fixed issues around Monolog compatibility and little details.
+* Authentication process edits after 2.16.0 release.
 
 == Frequently Asked Questions ==
 


### PR DESCRIPTION
This PR:

Releases 2.16.1

1. moves `ctct_init` and `maybe_connect` methods back to standard `init` action instead of potentially very late `cmb2_init`.
2. It removes original reliance on CMB2 being loaded as part of the `acquire_access_token()` process.
3. With the `refresh_token()` method, it amends the return value to better indicate where we're returning from, with an extra check for if we have a refresh token at all to use.
4. Deletes the `ctct_maybe_needs_reconnected` option on deactivation.