### PR TITLE
CON-506 Fix hCaptcha instantiation errors.

### DIFF
--- a/includes/class-captchaservice.php
+++ b/includes/class-captchaservice.php
@@ -83,7 +83,7 @@ class ConstantContact_CaptchaService {
 				return ConstantContact_hCaptcha::has_hcaptcha_keys();
 
 			case 'turnstile' :
-				return ConstantContact_turnstile::has_turnstile_keys();
+				return ConstantContact_Turnstile::has_turnstile_keys();
 
 			default:
 				return false;
@@ -117,7 +117,7 @@ class ConstantContact_CaptchaService {
 
 		$has_recaptcha_keys = ConstantContact_reCAPTCHA::has_recaptcha_keys();
 		$has_hcaptcha_keys  = ConstantContact_hCaptcha::has_hcaptcha_keys();
-		$has_turnstile_keys = ConstantContact_turnstile::has_turnstile_keys();
+		$has_turnstile_keys = ConstantContact_Turnstile::has_turnstile_keys();
 
 		// If the Google reCAPTCHA Site Key and Secret Key are set, set the Captcha Service to Google reCAPTCHA.
 		if ( ! empty( $has_recaptcha_keys ) ) {

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -100,9 +100,31 @@ class ConstantContact_Display {
 				$recaptcha->enqueue_scripts();
 			} elseif ( 'hcaptcha' === $captcha_service->get_selected_captcha_service() ) {
 				$hcaptcha = new ConstantContact_hCaptcha();
+
+				/**
+				 * Filters the language code to be used with hCaptcha.
+				 *
+				 * See https://docs.hcaptcha.com/languages/ for available values.
+				 *
+				 * @param string $value Language code to use. Default '' (makes hCaptcha autodetect).
+				 *
+				 * @since 2.16.2
+				 */
+				$hcaptcha->set_language( apply_filters( 'constant_contact_hcaptcha_lang', '' ) );
 				$hcaptcha->enqueue_scripts();
 			} elseif ( 'turnstile' === $captcha_service->get_selected_captcha_service() ) {
 				$turnstile = new ConstantContact_turnstile();
+
+				/**
+				 * Filters the language code to be used with Turnstile.
+				 *
+				 * See https://developers.cloudflare.com/turnstile/reference/supported-languages/ for available values.
+				 *
+				 * @param string $value Language code to use. Default '' (makes Turnstile autodetect).
+				 *
+				 * @since 2.16.2
+				 */
+				$turnstile->set_language( apply_filters( 'constant_contact_turnstile_lang', '' ) );
 				$turnstile->enqueue_scripts();
 			}
 		}

--- a/includes/class-display.php
+++ b/includes/class-display.php
@@ -113,7 +113,7 @@ class ConstantContact_Display {
 				$hcaptcha->set_language( apply_filters( 'constant_contact_hcaptcha_lang', '' ) );
 				$hcaptcha->enqueue_scripts();
 			} elseif ( 'turnstile' === $captcha_service->get_selected_captcha_service() ) {
-				$turnstile = new ConstantContact_turnstile();
+				$turnstile = new ConstantContact_Turnstile();
 
 				/**
 				 * Filters the language code to be used with Turnstile.
@@ -754,7 +754,7 @@ class ConstantContact_Display {
 	 * @return string
 	 */
 	public function build_turnstile( int $form_id ) : string {
-		$turnstile = new ConstantContact_turnstile();
+		$turnstile = new ConstantContact_Turnstile();
 
 		$turnstile->set_turnstile_keys();
 

--- a/includes/class-hcaptcha.php
+++ b/includes/class-hcaptcha.php
@@ -60,7 +60,7 @@ class ConstantContact_hCaptcha {
 	 * @var string
 	 * @since 2.9.0
 	 */
-	protected string $language;
+	protected string $language = '';
 
 	/**
 	 * Mode to use.

--- a/includes/class-health.php
+++ b/includes/class-health.php
@@ -68,7 +68,7 @@ class ConstantContact_Health {
 			$has_hcaptcha,
 		);
 
-		$has_turnstile    = ( ConstantContact_turnstile::has_turnstile_keys() ) ? $yes : $no;
+		$has_turnstile    = ( ConstantContact_Turnstile::has_turnstile_keys() ) ? $yes : $no;
 		$turnstile_status = sprintf(
 		/* Translators: Placeholders will store the current values from each */
 			esc_html__( 'Has Turnstile: %1$s', 'constant-contact-forms' ),

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -347,7 +347,7 @@ class ConstantContact_Process_Form {
 
 		// Handle verifying turnstile response.
 		if ( isset( $data['cf-turnstile-response'] ) && 'turnstile' === $captcha_sevice->get_selected_captcha_service() ) {
-			$ctctturnstile = new ConstantContact_turnstile();
+			$ctctturnstile = new ConstantContact_Turnstile();
 			$ctctturnstile->set_turnstile_keys();
 			$keys = $ctctturnstile->get_turnstile_keys();
 
@@ -380,7 +380,7 @@ class ConstantContact_Process_Form {
 		if (
 			! $maybe_disable_captcha &&
 			empty( $data['cf-turnstile-response'] )
-			&& ConstantContact_turnstile::has_turnstile_keys() &&
+			&& ConstantContact_Turnstile::has_turnstile_keys() &&
 			'turnstile' === $captcha_sevice->get_selected_captcha_service()
 		) {
 			return $spam_error_response;

--- a/includes/class-turnstile.php
+++ b/includes/class-turnstile.php
@@ -60,7 +60,7 @@ class ConstantContact_turnstile {
 	 * @var string
 	 * @since 2.16.0
 	 */
-	protected string $language;
+	protected string $language = '';
 
 	/**
 	 * Mode to use.

--- a/includes/class-turnstile.php
+++ b/includes/class-turnstile.php
@@ -12,11 +12,11 @@
 // phpcs:disable PEAR.NamingConventions.ValidClassName.Invalid -- OK classname.
 
 /**
- * Class ConstantContact_turnstile.
+ * Class ConstantContact_Turnstile.
  *
  * @since 2.16.0
  */
-class ConstantContact_turnstile {
+class ConstantContact_Turnstile {
 
 	/**
 	 * Turnstile site key.


### PR DESCRIPTION
Fixes https://app.clickup.com/t/9011385391/CON-506

This PR does the following:

1. Call the `set_language()` method immediately after instantiation with filters to match our Google reCAPTCHA offering for language filtering.
2. Set the property to empty string on instantiation inside the hCaptcha and Turnstile classes.
3. Adjusts Turnstile class naming to meet conventions.