### PR TITLE
Feature/con 508 email column

### DIFF
--- a/assets/sass/_admin-pages.scss
+++ b/assets/sass/_admin-pages.scss
@@ -135,6 +135,8 @@
 
   .ctct-shortcode-wrap{
     display: flex;
+    flex-direction: column;
+    gap: 8px;
     width: 100%;
     background-color: variables.$color-white;
     border: 1px solid variables.$color-silver;
@@ -170,7 +172,6 @@
     }
 
     button{
-      border-radius: variables.$radius;
       z-index: 1;
     }
   }

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -461,7 +461,7 @@ class ConstantContact_Admin {
 
 				if ( ! empty( $emailedto ) ) {
 					printf(
-						esc_html__( 'Emails sent to %1$s', 'constant-contact-forms' ),
+						esc_html__( 'Sends to %1$s', 'constant-contact-forms' ),
 						$emailedto
 					);
 				} else {

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -351,9 +351,10 @@ class ConstantContact_Admin {
 	 */
 	public function set_custom_columns( array $columns ) : array {
 
-		$columns['description'] = esc_html__( 'Description', 'constant-contact-forms' );
-		$columns['shortcodes']  = esc_html__( 'Shortcode', 'constant-contact-forms' );
-		$columns['ctct_list']   = esc_html__( 'Associated list', 'constant-contact-forms' );
+		$columns['description']  = esc_html__( 'Description', 'constant-contact-forms' );
+		$columns['shortcodes']   = esc_html__( 'Shortcode', 'constant-contact-forms' );
+		$columns['ctct_list']    = esc_html__( 'Associated list', 'constant-contact-forms' );
+		$columns['email_status'] = esc_html__( 'Email status', 'constant-contact-forms' );
 
 		return $columns;
 	}
@@ -379,6 +380,24 @@ class ConstantContact_Admin {
 
 		$table_list_ids = get_post_meta( $post_id, '_ctct_list', true );
 		$table_list_ids = is_array( $table_list_ids ) ? $table_list_ids : [ $table_list_ids ];
+
+		$disabled_for_form = false;
+		$locations = [];
+		$form_status = get_post_meta( $post_id, '_ctct_disable_emails_for_form', true );
+		if ( 'on' === $form_status ) {
+			$disabled_for_form = true;
+			$locations[] = esc_html__( 'Form settings', 'constant-contact-forms' );
+		}
+		$settings_status = constant_contact_get_option( '_ctct_disable_email_notifications' );
+		if ( 'on' === $settings_status ) {
+			$disabled_for_form = true;
+			$locations[] = esc_html__( 'Plugin settings', 'constant-contact-forms' );
+		}
+
+		$emailedto = '';
+		if ( empty( $form_status ) && empty( $settings_status ) ) {
+			$emailedto = constant_contact()->get_mail()->get_email( $post_id );
+		}
 
 		switch ( $column ) {
 			case 'shortcodes':
@@ -423,6 +442,31 @@ class ConstantContact_Admin {
 				}
 
 				echo wp_kses_post( implode( ', ', $list_html ) );
+				break;
+			case 'email_status':
+
+				if ( $disabled_for_form ) {
+					esc_html_e( 'Disabled', 'constant-contact-forms' );
+					echo '<br/>';
+					echo esc_html(
+						sprintf(
+							'Locations: %1$s',
+							implode( ', ', $locations )
+						)
+					);
+				}
+
+				if ( ! empty( $emailedto ) ) {
+					printf(
+						esc_html__( 'Emails sent to %1$s', 'constant-contact-forms' ),
+						$emailedto
+					);
+				} else {
+					if ( ! $disabled_for_form ) {
+						esc_html_e( 'Sends to site admin email.', 'constant-contact-forms' );
+					}
+				}
+
 				break;
 		}
 	}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -401,13 +401,16 @@ class ConstantContact_Admin {
 
 		switch ( $column ) {
 			case 'shortcodes':
-				echo '<div class="ctct-shortcode-wrap"><input class="ctct-shortcode" type="text" value="';
-				echo esc_html( '[ctct form="' . $post_id . '" show_title="false"]' );
-				echo '" readonly="readonly">';
-				echo '<button type="button" class="button" data-copied="' . esc_html__( 'Copied!', 'constant-contact-forms' ) . '">';
-				echo esc_html__( 'Copy', 'constant-contact-forms' );
-				echo '</button>';
-				echo '</div>';
+				$tmpl = '<div class="ctct-shortcode-wrap">
+					<button type="button" class="button" data-copied="%1$s">%2$s</button>
+					<input class="ctct-shortcode" type="text" value="%3$s" readonly>
+					</div>';
+				printf(
+					$tmpl,
+					esc_attr__( 'Copied!', 'constant-contact-forms' ),
+					esc_html__( 'Copy', 'constant-contact-forms' ),
+					esc_attr( '[ctct form="' . $post_id . '" show_title="false"]' )
+				);
 				break;
 			case 'description':
 				echo wp_kses_post( wpautop( get_post_meta( $post_id, '_ctct_description', true ) ) );

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -382,16 +382,16 @@ class ConstantContact_Admin {
 		$table_list_ids = is_array( $table_list_ids ) ? $table_list_ids : [ $table_list_ids ];
 
 		$disabled_for_form = false;
-		$locations = [];
-		$form_status = get_post_meta( $post_id, '_ctct_disable_emails_for_form', true );
+		$locations         = [];
+		$form_status       = get_post_meta( $post_id, '_ctct_disable_emails_for_form', true );
 		if ( 'on' === $form_status ) {
 			$disabled_for_form = true;
-			$locations[] = esc_html__( 'Form settings', 'constant-contact-forms' );
+			$locations[]       = esc_html__( 'Form settings', 'constant-contact-forms' );
 		}
 		$settings_status = constant_contact_get_option( '_ctct_disable_email_notifications' );
 		if ( 'on' === $settings_status ) {
 			$disabled_for_form = true;
-			$locations[] = esc_html__( 'Plugin settings', 'constant-contact-forms' );
+			$locations[]       = esc_html__( 'Plugin settings', 'constant-contact-forms' );
 		}
 
 		$emailedto = '';


### PR DESCRIPTION
This PR does the following:

1. Adds a new admin column for our forms post type.
2. If emails are disabled for the specific form, states that
3. If emails are disabled overall via settings, states that.
4. If no locations are disabled, lists the destination emails for the given form.
5. Adjusts shortcode column markup and styles to better accommodate for space