### PR TITLE
CAPTCHA guarding

### DIFF
--- a/assets/js/ctct-plugin-admin/settings.js
+++ b/assets/js/ctct-plugin-admin/settings.js
@@ -37,6 +37,9 @@ window.ctctsettings = {};
 	 */
 	that.bindEvents = () => {
 		const service = document.querySelector(that.cache.service);
+		if (null === service) {
+			return;
+		}
 		const recaptcha = document.querySelector(that.cache.recaptcha);
 		const hcaptcha = document.querySelector(that.cache.hcaptcha);
 		const turnstile = document.querySelector(that.cache.turnstile);


### PR DESCRIPTION
This PR adds an early return to our settings page js around spam. This will prevent errors from being logged when the service selector is not available, which is most everywhere else in the admin.

https://app.clickup.com/t/9011385391/CON-522