### PR TITLE
touch up button icon margins for incoming WP 7.0

### DIFF
--- a/assets/sass/_admin-forms.scss
+++ b/assets/sass/_admin-forms.scss
@@ -300,3 +300,11 @@ body.post-type-ctct_forms #titlediv #title {
 		}
 	}
 }
+
+
+[class*="version-7"] {
+  .cmb-repeatable-group .cmb-shift-rows .dashicons-arrow-down-alt2,
+  .cmb-repeatable-group .cmb-shift-rows .dashicons-arrow-up-alt2 {
+	margin-top: .4em;
+  }
+}


### PR DESCRIPTION
This PR adjusts some margins for CMB2 buttons to better match button display for WP 7.0+