### PR TITLE
Feature/con 519 api requests auditing

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1623,7 +1623,7 @@ class ConstantContact_API {
 			$data            = json_decode( $response['body'], true );
 			$json_last_error = json_last_error();
 			if ( JSON_ERROR_NONE !== $json_last_error ) {
-				constant_contact_maybe_log_it( 'JSON Error: ', json_last_error_msg() );
+				constant_contact_maybe_log_it( 'JSON error: ', json_last_error_msg() );
 			}
 
 			// check if the body contains error

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1614,7 +1614,12 @@ class ConstantContact_API {
 		$this->status_code = 0;
 
 		if ( ! is_wp_error( $response ) ) {
-
+			if ( empty( $response['body'] ) ) {
+				constant_contact_maybe_log_it(
+					'Response error: ', implode( ":", $response['response'] )
+				);
+				return false;
+			}
 			$data            = json_decode( $response['body'], true );
 			$json_last_error = json_last_error();
 			if ( JSON_ERROR_NONE !== $json_last_error ) {


### PR DESCRIPTION
This PR amends the `exec()` method to return early if we do not have a response body to JSON decode.

This is most often the case with a `429 error` aka "Too Many Requests"