### PR TITLE
Force disconnect if current site+user does not match the site+user that the access token was originally created on.

### DIFF
--- a/includes/class-api-utility.php
+++ b/includes/class-api-utility.php
@@ -167,7 +167,7 @@ class ConstantContact_API_Utility {
 	/**
 	 * Parse and extract access token data for authenticated account email and current website.
 	 *
-	 * @since NEXT
+	 * @since 2.19.0
 	 *
 	 * @param string $access_token
 	 * @return array

--- a/includes/class-api-utility.php
+++ b/includes/class-api-utility.php
@@ -163,4 +163,38 @@ class ConstantContact_API_Utility {
 		$start = substr( $data_item, 0, 8 );
 		return $start . '***';
 	}
+
+	/**
+	 * Parse and extract access token data for authenticated account email and current website.
+	 *
+	 * @since NEXT
+	 *
+	 * @param string $access_token
+	 * @return array
+	 */
+	public function parse_access_token_data( string $access_token ) {
+		if ( empty( $access_token ) ) {
+			return [];
+		}
+		$connecting_account = [];
+
+		// Not a PHP error, just assigning only 1 variable of 3 available.
+		list( , $payload ) = explode( '.', $access_token );
+
+		$payload_data = '';
+		if ( ! empty( $payload ) && is_string( $payload ) ) {
+			$payload_data = base64_decode( $payload );
+		}
+
+		if ( ! empty( $payload_data ) ) {
+			$parsed_payload_data = json_decode( $payload_data, true );
+			if ( JSON_ERROR_NONE !== json_last_error() ) {
+				return [];
+			}
+			$connecting_account['account'] = $parsed_payload_data['sub'];
+			$connecting_account['site']    = get_site_url();
+		}
+
+		return $connecting_account;
+	}
 }

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -186,6 +186,32 @@ class ConstantContact_API {
 		$this->refresh_token = constant_contact()->get_connect()->e_get( '_ctct_refresh_token' );
 		$this->access_token  = constant_contact()->get_connect()->e_get( '_ctct_access_token' );
 
+		if ( ! empty( $this->access_token ) ) {
+			$account_domain = constant_contact()->get_api_utility()->parse_access_token_data( $this->access_token );
+			if ( ! empty( $account_domain ) ) {
+				$current_hash = hash( 'sha256', implode( '|', $account_domain ) );
+				$saved_hash   = get_option( 'ctct_account_domain_hash', '' );
+			}
+
+			if ( is_admin() ) {
+				if ( ! empty( $saved_hash ) && ! empty( $current_hash ) ) {
+					if ( ! hash_equals( $saved_hash, $current_hash ) ) {
+						add_action( 'admin_notices', function () use ( $account_domain ) {
+							wp_admin_notice(
+								sprintf(
+									esc_html__( 'Constant Contact Forms has detected a different domain from the one originally connected to. We have force disconnected this install to preserve that original connection. Original connecting account is %s', 'constant-contact-forms' ),
+									$account_domain['account']
+								),
+								[ 'dismissible' => true ]
+							);
+						} );
+						constant_contact()->get_connect()->force_disconnect();
+						return false;
+					}
+				}
+			}
+		}
+
 		// Attempt to acquire access token if we don't have it already.
 		// This fixes an issue where authorization does not work sometimes when switching between different accounts.
 		if (

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -620,6 +620,10 @@ class ConstantContact_API {
 					'Current time: ' . $dateObj->format( 'Y-n-d, H:i' ) . ' Estimated expiration time: ' . $expDateObj->format( 'Y-n-d, H:i' )
 				);
 
+				$account_domain      = constant_contact()->get_api_utility()->parse_access_token_data( $data['access_token'] );
+				$account_domain_hash = hash( 'sha256', implode( '|', $account_domain ) );
+				update_option( 'ctct_account_domain_hash', $account_domain_hash );
+
 				return isset( $data['access_token'], $data['refresh_token'] );
 			}
 		} else {

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -363,32 +363,45 @@ class ConstantContact_Connect {
 		}
 
 		if ( wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['ctct-admin-disconnect'] ) ), 'ctct-admin-disconnect' ) ) {
-
-			delete_option( 'ctct_access_token' );
-			delete_option( '_ctct_access_token' );
-			delete_option( 'ctct_refresh_token' );
-			delete_option( '_ctct_refresh_token' );
-			delete_option( '_ctct_expires_in' );
-			delete_option( 'ctct_maybe_needs_reconnected' );
-
-			delete_option( 'CtctConstantContactcode_verifier' );
-			delete_option( 'CtctConstantContactState' );
-			delete_option( 'ctct_auth_url' );
-			delete_option( 'ctct_key' );
-
-			constant_contact_delete_option( '_ctct_form_state_authcode' );
-
-			wp_clear_scheduled_hook( 'refresh_token_job' );
-			wp_unschedule_hook( 'refresh_token_job' );
-
-			$saved_options = get_option( 'ctct_options_settings' );
-			if ( isset( $saved_options['_ctct_disable_email_notifications'] ) ) {
-				unset( $saved_options['_ctct_disable_email_notifications'] );
-				update_option( 'ctct_options_settings', $saved_options );
-			}
+			$this->force_disconnect();
 		} else {
 			constant_contact_maybe_log_it( 'Nonces', 'Account disconnection nonce failed to verify.' );
 		}
+		return true;
+	}
+
+	/**
+	 *  Force disconnect from Constant Contact.
+	 *
+	 * @since NEXT
+	 *
+	 * @return bool
+	 */
+	public function force_disconnect() : bool {
+		delete_option( 'ctct_access_token' );
+		delete_option( '_ctct_access_token' );
+		delete_option( 'ctct_refresh_token' );
+		delete_option( '_ctct_refresh_token' );
+		delete_option( '_ctct_expires_in' );
+		delete_option( 'ctct_maybe_needs_reconnected' );
+		delete_option( 'ctct_account_domain_hash' );
+
+		delete_option( 'CtctConstantContactcode_verifier' );
+		delete_option( 'CtctConstantContactState' );
+		delete_option( 'ctct_auth_url' );
+		delete_option( 'ctct_key' );
+
+		constant_contact_delete_option( '_ctct_form_state_authcode' );
+
+		wp_clear_scheduled_hook( 'refresh_token_job' );
+		wp_unschedule_hook( 'refresh_token_job' );
+
+		$saved_options = get_option( 'ctct_options_settings' );
+		if ( isset( $saved_options['_ctct_disable_email_notifications'] ) ) {
+			unset( $saved_options['_ctct_disable_email_notifications'] );
+			update_option( 'ctct_options_settings', $saved_options );
+		}
+
 		return true;
 	}
 

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -373,7 +373,7 @@ class ConstantContact_Connect {
 	/**
 	 * Force disconnect from Constant Contact.
 	 *
-	 * @since NEXT
+	 * @since 2.19.0
 	 *
 	 * @return bool
 	 */

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -371,7 +371,7 @@ class ConstantContact_Connect {
 	}
 
 	/**
-	 *  Force disconnect from Constant Contact.
+	 * Force disconnect from Constant Contact.
 	 *
 	 * @since NEXT
 	 *

--- a/includes/class-uninstall.php
+++ b/includes/class-uninstall.php
@@ -63,6 +63,7 @@ class ConstantContact_Uninstall {
 			'ctct_missed_api_requests',
 			'ctct_log_suffix',
 			'ctct_refresh_failures',
+			'ctct_account_domain_hash',
 			Constant_Contact::$activated_date_option,
 			ConstantContact_Notifications::$dismissed_notices_option,
 			ConstantContact_Notifications::$review_dismissed_option,


### PR DESCRIPTION
This PR makes the following changes and updates:

1. Parses access token to extract account used.
2. Hashes and saves a combination of connecting account and current website url.
3. Actively compares the current site+user hash to saved version.
4. If a mismatch is determined, force disconnect the current site with admin notice explaining why.