### PR TITLE
Only show copy button on secure connection sites.

### DIFF
--- a/assets/sass/_admin-pages.scss
+++ b/assets/sass/_admin-pages.scss
@@ -133,7 +133,7 @@
 
   // Copy shortcode on form listing.
 
-  .ctct-shortcode-wrap{
+  .ctct-shortcode-wrap.ssl{
     display: flex;
     flex-direction: column;
     gap: 8px;

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -401,16 +401,24 @@ class ConstantContact_Admin {
 
 		switch ( $column ) {
 			case 'shortcodes':
-				$tmpl = '<div class="ctct-shortcode-wrap">
+				if ( is_ssl() ) {
+					$tmpl = '<div class="ctct-shortcode-wrap ssl">
 					<button type="button" class="button" data-copied="%1$s">%2$s</button>
 					<input class="ctct-shortcode" type="text" value="%3$s" readonly>
 					</div>';
-				printf(
-					$tmpl,
-					esc_attr__( 'Copied!', 'constant-contact-forms' ),
-					esc_html__( 'Copy', 'constant-contact-forms' ),
-					esc_attr( '[ctct form="' . $post_id . '" show_title="false"]' )
-				);
+					printf(
+						$tmpl,
+						esc_attr__( 'Copied!', 'constant-contact-forms' ),
+						esc_html__( 'Copy', 'constant-contact-forms' ),
+						esc_attr( '[ctct form="' . $post_id . '" show_title="false"]' )
+					);
+				} else {
+					$tmpl = '<div class="ctct-shortcode-wrap no-ssl"><p>%1$s</p></div>';
+					printf(
+						$tmpl,
+						esc_html( '[ctct form="' . $post_id . '" show_title="false"]' )
+					);
+				}
 				break;
 			case 'description':
 				echo wp_kses_post( wpautop( get_post_meta( $post_id, '_ctct_description', true ) ) );


### PR DESCRIPTION
# Fixes

https://app.clickup.com/t/9011385391/CON-525

# Description

If we're not on a secure website, the copy/clipboard won't work, and will appear broken. Because of this, if not on a secure site, we're going to not have that UI and just output a plaintext version of the generated shortcode to manually select for copy/paste.