### PR TITLE
early return for AJAX requests and potentially avoid token status issues

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -180,6 +180,10 @@ class ConstantContact_API {
 			return false;
 		}
 
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			return false;
+		}
+
 		$this->this_user_id = get_current_user_id();
 
 		$this->expires_in    = constant_contact()->get_connect()->e_get( '_ctct_expires_in' );


### PR DESCRIPTION
This PR returns early in our `ctct_init` callback, if the current request is an AJAX request.

We don't need to be doing checks on those requests, and currently are potentially causing excess risk of token failure by having these run.