### PR TITLE
Feature/con 527 various UI fixes

### DIFF
--- a/assets/sass/_admin-compatibility.scss
+++ b/assets/sass/_admin-compatibility.scss
@@ -1,0 +1,14 @@
+.ctct-page-wrap,
+.cmb2-postbox {
+	.cmb2-wrap {
+		input:focus,
+		textarea:focus {
+			background: inherit;
+		}
+
+		input:checked,
+		textarea:checked {
+			background: var(--wp-admin-theme-color);
+		}
+	}
+}

--- a/assets/sass/_admin-forms.scss
+++ b/assets/sass/_admin-forms.scss
@@ -17,6 +17,13 @@
 	}
 }
 
+#poststuff {
+  p.cmb2-metabox-description,
+  span.cmb2-metabox-description {
+	color: inherit;
+  }
+}
+
 body.post-type-ctct_lists .misc-pub-post-status {
 	display: none;
 }

--- a/assets/sass/_admin-forms.scss
+++ b/assets/sass/_admin-forms.scss
@@ -150,7 +150,6 @@ body.post-type-ctct_forms #titlediv #title {
 	button {
 
 		&.cmb-remove-group-row {
-			background: variables.$color-cmb-button-pale-yellow !important;
 			display: none;
 		}
 	}

--- a/assets/sass/_admin-pages.scss
+++ b/assets/sass/_admin-pages.scss
@@ -92,11 +92,6 @@
     }
   }
 
-  hr{
-    border-top: none;
-    border-color: variables.$color-silver;
-  }
-
   // Align elements in settings form tables.
 
   form.cmb-form{

--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -15,7 +15,6 @@ $color-orange-alt: #e38400;
 // Grayscale
 $color-black: #000;
 $color-gray: #aaa;
-$color-also-silver: #ccc;
 $color-silver: #ddd;
 $color-light-gray: #e9e9e9;
 $color-lighter-gray: #f7f7f7;
@@ -54,9 +53,6 @@ $shadow: 0 1px 5px rgba(0, 0, 0, 0.055);
 $shadow_lg: 0 4px 10px rgba(0, 0, 0, 0.065);
 
 // CMB Buttons
-$color-cmb-button-light-blue: #008ec2;
-$color-cmb-button-blue: #006799;
-$color-cmb-button-pale-yellow: #ffdfa3;
 $color-cmb-description-text: rgb(68, 68, 68);
 
 // Modal

--- a/assets/sass/admin-style.scss
+++ b/assets/sass/admin-style.scss
@@ -17,3 +17,4 @@
 @use 'admin-pages';
 @use 'admin-attached-lists';
 @use 'admin-settings';
+@use 'admin-compatibility';

--- a/includes/class-admin-pages.php
+++ b/includes/class-admin-pages.php
@@ -74,7 +74,7 @@ class ConstantContact_Admin_Pages {
 		<h2><?php esc_html_e( 'About Constant Contact Forms', 'constant-contact-forms' ); ?></h2>
 		<div class="constant-contact-about">
 			<div class="ctct-section section-about">
-				<p class="large-text">
+				<p>
 					<?php echo wp_kses_post( esc_html__( "This plugin makes it fast and easy to capture all kinds of visitor information right from your WordPress site—even if you don't have a Constant Contact account.", 'constant-contact-forms' ) ); ?>
 				</p>
 			</div>

--- a/includes/class-admin-pages.php
+++ b/includes/class-admin-pages.php
@@ -75,7 +75,7 @@ class ConstantContact_Admin_Pages {
 		<div class="constant-contact-about">
 			<div class="ctct-section section-about">
 				<p>
-					<?php echo wp_kses_post( esc_html__( "This plugin makes it fast and easy to capture all kinds of visitor information right from your WordPress site—even if you don't have a Constant Contact account.", 'constant-contact-forms' ) ); ?>
+					<?php echo wp_kses_post( esc_html__( "Constant Contact Forms makes it fast and easy to capture all kinds of visitor information right from your WordPress site—even if you don't have a Constant Contact account.", 'constant-contact-forms' ) ); ?>
 				</p>
 			</div>
 			<div class="ctct-section ctct-features">

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -486,7 +486,7 @@ class ConstantContact_Admin {
 	 * @return array
 	 */
 	public function set_custom_lists_columns( array $columns ) : array {
-		$columns['ctct_total'] = esc_html__( 'Contact count', 'constant-contact-forms' );
+		$columns['ctct_total'] = esc_html__( 'Membership count', 'constant-contact-forms' );
 
 		unset( $columns['date'] );
 

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -137,7 +137,17 @@ class ConstantContact_Lists {
 
 		echo '<ul>';
 
-		unset( $list_info['id'], $list_info['status'] );
+		echo wp_kses_post(
+			sprintf(
+				'<li>%s</li>',
+				sprintf(
+					esc_html__( '%1$s View in Constant Contact %2$s', 'constant-contact-forms' ),
+					'<a href="https://app.constantcontact.com/contacts/lists/' . esc_attr( $list_info['list_id'] ) . '">',
+					'</a>'
+				)
+
+			)
+		);
 
 		if ( isset( $list_info['created_at'] ) && $list_info['created_at'] ) {
 			$list_info['created_at'] = date( 'l, F jS, Y g:i A', strtotime( $list_info['created_at'] ) ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
@@ -146,6 +156,9 @@ class ConstantContact_Lists {
 		if ( isset( $list_info['updated_at'] ) && $list_info['updated_at'] ) {
 			$list_info['updated_at'] = date( 'l, F jS, Y g:i A', strtotime( $list_info['updated_at'] ) ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 		}
+
+		// Already linked, don't display.
+		unset( $list_info['list_id'] );
 
 		foreach ( $list_info as $key => $value ) {
 			$key = sanitize_text_field( $key );

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -161,11 +161,14 @@ class ConstantContact_Lists {
 		unset( $list_info['list_id'] );
 
 		foreach ( $list_info as $key => $value ) {
+			if ( 'favorite' === $key ) {
+				$value = ( empty( $value ) ? 'no' : 'yes' );
+			}
 			$key = sanitize_text_field( $key );
 			$key = str_replace( '_', ' ', $key );
 			$key = ucwords( $key );
 
-			echo wp_kses_post( '<li><b>' . $key . '</b> : ' . sanitize_text_field( $value ) . '</li>' );
+			echo wp_kses_post( '<li><strong>' . $key . '</strong>: ' . sanitize_text_field( $value ) . '</li>' );
 		}
 
 		echo '</ul>';

--- a/includes/class-lists.php
+++ b/includes/class-lists.php
@@ -130,9 +130,7 @@ class ConstantContact_Lists {
 
 		$list_info = constant_contact()->get_api()->get_list( esc_attr( $list_id ) );
 
-		// Comes in as an array.
-		$list_info_obj = (object) $list_info;
-		if ( ! isset( $list_info_obj->list_id ) ) {
+		if ( ! isset( $list_info['list_id'] ) ) {
 			echo wp_kses_post( $this->get_list_info_no_data() );
 			return;
 		}

--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -249,7 +249,7 @@ class ConstantContact_Logging {
 			}
 
 			?>
-			<p class="large-text"><?php esc_html_e( 'The error log below can be used with support requests to help identify issues with Constant Contact Forms.', 'constant-contact-forms' ); ?></p>
+			<p><?php esc_html_e( 'The error log below can be used with support requests to help identify issues with Constant Contact Forms.', 'constant-contact-forms' ); ?></p>
 			<p><?php esc_html_e( 'When available, you can share information by copying and pasting the content in the textarea, or by using the "Download logs" link below. Logs can be cleared by using the "Delete logs" link.', 'constant-contact-forms' ); ?></p>
 			<label for="ctct_error_logs"><textarea name="ctct_error_logs" id="ctct_error_logs" cols="80" rows="40" onclick="this.focus();this.select();" onfocus="this.focus();this.select();" readonly="readonly" aria-readonly="true"><?php echo esc_html( $contents ); ?></textarea></label>
 			<?php

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -358,7 +358,7 @@ class ConstantContact_Settings {
 					'name'       => esc_html__( 'Disable e-mail notifications', 'constant-contact-forms' ),
 					'desc'       => sprintf(
 					/* Translators: Placeholder is for a <br /> HTML tag. */
-						esc_html__( 'This option will disable e-mail notifications for forms with a selected list and successfully submit to Constant Contact.%s Notifications are sent to the email address listed under WordPress "General Settings".', 'constant-contact-forms' ),
+						esc_html__( 'This option will disable e-mail notifications for forms with a selected list and successfully submit to Constant Contact.%s Notifications are sent to the email address listed under WordPress "General Settings" or selected addresses for each form.', 'constant-contact-forms' ),
 						'<br/>'
 					),
 					'id'         => '_ctct_disable_email_notifications',

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -363,7 +363,6 @@ class ConstantContact_Settings {
 					),
 					'id'         => '_ctct_disable_email_notifications',
 					'type'       => 'checkbox',
-					'before_row' => '<hr/>',
 				]
 			);
 		}
@@ -388,7 +387,7 @@ class ConstantContact_Settings {
 		$cmb = new_cmb2_box( $this->get_cmb_args( 'styles' ) );
 
 		$before_global_css = sprintf(
-			'<hr><h2>%s</h2>',
+			'<h2>%s</h2>',
 			esc_html__( 'Global Form CSS Settings', 'constant-contact-forms' )
 		);
 
@@ -463,7 +462,7 @@ class ConstantContact_Settings {
 			if ( $lists && is_array( $lists ) ) {
 
 				$before_optin = sprintf(
-					'<hr><h2>%s</h2>',
+					'<h2>%s</h2>',
 					esc_html__( 'Advanced opt-in', 'constant-contact-forms' )
 				);
 
@@ -736,7 +735,7 @@ class ConstantContact_Settings {
 		);
 
 		$before_message = sprintf(
-			'<hr/><h2>%s</h2><div class="description">%s</div>',
+			'<h2>%s</h2><div class="description">%s</div>',
 			esc_html__( 'Suspected bot error message', 'constant-contact-forms' ),
 			esc_html__( 'This message displays when the plugin detects spam data. Note that this message may be overriden on a per-post basis.', 'constant-contact-forms' )
 		);

--- a/includes/notification-logic.php
+++ b/includes/notification-logic.php
@@ -293,6 +293,12 @@ function constant_contact_maybe_show_lists_selection_notification(): bool {
 	}
 
 	if ( isset( $_GET['post'] ) && is_numeric( $_GET['post'] ) ) {
+		$type = get_post_type( $_GET['post'] );
+
+		if ( 'ctct_forms' !== $type ) {
+			return false;
+		}
+
 		$thepostmeta = get_post_meta( absint( $_GET['post'] ) );
 
 		return empty( $thepostmeta['_ctct_list'] );


### PR DESCRIPTION
This PR makes the following changes:

1. Adjusts CSS around CMB2 which causes confusion for clicked/focused status.
2. Adjusts wording for list column around membership count.
3. Adds link to ConstantContact.com and the currently viewed list.
4. Removes array to object conversion that is not needed.
5. Returns early for a notification regarding choosing a list, meant for the form builder only
6. Converts "favorite" status for a list to read "yes" or "no" instead of empty string or numerical 1
7. Removes `large-text` class from a logging page paragraph
8. Updates text for email settings.
9. Removes custom color on "remove field" button.