### PR TITLE
log details around domains upon connection and hash mismatches.

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -209,6 +209,7 @@ class ConstantContact_API {
 								[ 'dismissible' => true ]
 							);
 						} );
+						constant_contact_maybe_log_it( 'API', 'Hashed domain mismatch. The following domain does not match the original connecting domain value: ' . esc_html( $account_domain['site'] ) );
 						constant_contact()->get_connect()->force_disconnect();
 						return false;
 					}
@@ -652,6 +653,7 @@ class ConstantContact_API {
 
 				$account_domain      = constant_contact()->get_api_utility()->parse_access_token_data( $data['access_token'] );
 				$account_domain_hash = hash( 'sha256', implode( '|', $account_domain ) );
+				constant_contact_maybe_log_it( 'API', 'Hash-stored domain: ' . $account_domain['site'] );
 				update_option( 'ctct_account_domain_hash', $account_domain_hash );
 
 				return isset( $data['access_token'], $data['refresh_token'] );


### PR DESCRIPTION
# Handles

[CON-533](https://app.clickup.com/t/9011385391/CON-533)

This PR adds some extra log details for connected domain for a given activation, and then a log if the current domain does not match a hashed value.

Logically should only mismatch if database data was recently migrated.