### PR TITLE
syncronize cron naming for better consistency and hopefully more stable runs

### DIFF
--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -510,8 +510,8 @@ class Constant_Contact {
 		delete_option( 'ctct_key' );
 		delete_option( 'ctct_maybe_needs_reconnected' );
 		constant_contact_delete_option( '_ctct_form_state_authcode' );
-		wp_clear_scheduled_hook( 'refresh_token_job' );
-		wp_unschedule_hook( 'refresh_token_job' );
+		wp_clear_scheduled_hook( 'ctct_refresh_token_job' );
+		wp_unschedule_hook( 'ctct_refresh_token_job' );
 
 		$this->notifications->delete_dismissed_notification( 'activation' );
 	}

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -395,8 +395,8 @@ class ConstantContact_Connect {
 
 		constant_contact_delete_option( '_ctct_form_state_authcode' );
 
-		wp_clear_scheduled_hook( 'refresh_token_job' );
-		wp_unschedule_hook( 'refresh_token_job' );
+		wp_clear_scheduled_hook( 'ctct_refresh_token_job' );
+		wp_unschedule_hook( 'ctct_refresh_token_job' );
 
 		$saved_options = get_option( 'ctct_options_settings' );
 		if ( isset( $saved_options['_ctct_disable_email_notifications'] ) ) {

--- a/includes/class-health.php
+++ b/includes/class-health.php
@@ -121,7 +121,7 @@ class ConstantContact_Health {
 				],
 				[
 					'label' => esc_html__( 'Token refresh cron scheduled?', 'constant-contact-forms' ),
-					'value' => ( wp_next_scheduled( 'refresh_token_job' ) ) ? $yes : $no,
+					'value' => ( wp_next_scheduled( 'ctct_refresh_token_job' ) ) ? $yes : $no,
 				],
 				[
 					'label' => esc_html__( 'Cron check', 'constant-contact-forms' ),


### PR DESCRIPTION
# Handles

[CON-539](https://app.clickup.com/t/9011385391/CON-539)

# Description

This PR handles synchronizing our cron job hook calls, most specifically around intended clearing of scheduled items. We were only ever scheduling on one name, but all forced clearing was on a mismatched name.

For scoping sake and avoiding generic naming, we're going with the prefixed version.