### PR TITLE
Feature/con 541 api hardening

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -385,7 +385,7 @@ class ConstantContact_API {
 			/**
 			 * Sets the HTTP timeout, in seconds, for the request.
 			 *
-			 * @since NEXT
+			 * @since 2.20.0
 			 *
 			 * @param int    30           The timeout limit, in seconds. Defaults to 30.
 			 * @param string $request_url The request URL.
@@ -463,7 +463,7 @@ class ConstantContact_API {
 			/**
 			 * Sets the HTTP timeout, in seconds, for the request.
 			 *
-			 * @since NEXT
+			 * @since 2.20.0
 			 *
 			 * @param int    30           The timeout limit, in seconds. Defaults to 30.
 			 * @param string $request_url The request URL.

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -382,6 +382,17 @@ class ConstantContact_API {
 		$options = [
 			'body'    => $body,
 			'headers' => $headers,
+			/**
+			 * Sets the HTTP timeout, in seconds, for the request.
+			 *
+			 * @since NEXT
+			 *
+			 * @param int    30           The timeout limit, in seconds. Defaults to 30.
+			 * @param string $request_url The request URL.
+			 *
+			 * @return int
+			 */
+			'timeout' => apply_filters( 'http_request_timeout', 30, $url )
 		];
 
 		// This will be either true or false.
@@ -449,6 +460,17 @@ class ConstantContact_API {
 		$options = [
 			'body'    => $body,
 			'headers' => $headers,
+			/**
+			 * Sets the HTTP timeout, in seconds, for the request.
+			 *
+			 * @since NEXT
+			 *
+			 * @param int    30           The timeout limit, in seconds. Defaults to 30.
+			 * @param string $request_url The request URL.
+			 *
+			 * @return int
+			 */
+			'timeout' => apply_filters( 'http_request_timeout', 30, $url )
 		];
 
 		$result = $this->exec( $url, $options );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -493,6 +493,7 @@ class ConstantContact_API {
 			} else {
 				constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh failed (attempt ' . $failures . '/5). Will retry. Attempted at ' . current_datetime()->format( 'Y-n-d, H:i' ) );
 				$status['reason'] = 'transient_failure';
+				$this->refresh_token();
 			}
 
 			$status['success'] = false;

--- a/includes/class-client.php
+++ b/includes/class-client.php
@@ -285,11 +285,23 @@ class ConstantContact_Client {
 	 */
 	private function get( string $endpoint, array $args = [] ) : array {
 
+		$url = $this->base_url . $endpoint;
+
 		$options = [
+			/**
+			 * Sets the HTTP timeout, in seconds, for the request.
+			 *
+			 * @since NEXT
+			 *
+			 * @param int    30           The timeout limit, in seconds. Defaults to 30.
+			 * @param string $request_url The request URL.
+			 *
+			 * @return int
+			 */
+			'timeout' => apply_filters( 'http_request_timeout', 30, $url ),
 			'headers' => $args,
 		];
 
-		$url = $this->base_url . $endpoint;
 
 		$response = wp_safe_remote_get( $url, $options );
 		if ( is_wp_error( $response ) ) {
@@ -313,15 +325,23 @@ class ConstantContact_Client {
 	 */
 	private function post( string $endpoint, array $args = [], array $body = [] ) : array {
 
-		$options = [
-			'headers' => $args,
-		];
-
-		if ( isset( $body ) ) {
-			$options['body'] = wp_json_encode( $body );
-		}
-
 		$url = $this->base_url . $endpoint;
+
+		$options = [
+			/**
+			 * Sets the HTTP timeout, in seconds, for the request.
+			 *
+			 * @since NEXT
+			 *
+			 * @param int    30           The timeout limit, in seconds. Defaults to 30.
+			 * @param string $request_url The request URL.
+			 *
+			 * @return int
+			 */
+			'timeout' => apply_filters( 'http_request_timeout', 30, $url ),
+			'headers' => $args,
+			'body'    => isset( $body ) ? wp_json_encode( $body ) : null,
+		];
 
 		$response = wp_safe_remote_post( $url, $options );
 
@@ -346,17 +366,24 @@ class ConstantContact_Client {
 	 */
 	private function put( string $endpoint, array $args = [], array $body = [] ) : array {
 
-		$options = [
-			'headers' => $args,
-		];
-
-		if ( isset( $body ) ) {
-			$options['body'] = wp_json_encode( $body );
-		}
-
 		$url = $this->base_url . $endpoint;
 
-		$options['method'] = 'PUT';
+		$options = [
+			/**
+			 * Sets the HTTP timeout, in seconds, for the request.
+			 *
+			 * @since NEXT
+			 *
+			 * @param int    30           The timeout limit, in seconds. Defaults to 30.
+			 * @param string $request_url The request URL.
+			 *
+			 * @return int
+			 */
+			'timeout' => apply_filters( 'http_request_timeout', 30, $url ),
+			'headers' => $args,
+			'method'  => 'PUT',
+			'body'    => isset( $body ) ? wp_json_encode( $body ) : null,
+		];
 
 		$response = wp_safe_remote_request( $url, $options );
 
@@ -379,13 +406,24 @@ class ConstantContact_Client {
 	 * @return array
 	 */
 	private function delete( string $endpoint, array $args = [] ) : array {
-		$options = [
-			'headers' => $args,
-		];
 
 		$url = $this->base_url . $endpoint;
 
-		$options['method'] = 'DELETE';
+		$options = [
+			/**
+			 * Sets the HTTP timeout, in seconds, for the request.
+			 *
+			 * @since NEXT
+			 *
+			 * @param int    30           The timeout limit, in seconds. Defaults to 30.
+			 * @param string $request_url The request URL.
+			 *
+			 * @return int
+			 */
+			'timeout' => apply_filters( 'http_request_timeout', 30, $url ),
+			'headers' => $args,
+			'method'  => 'DELETE',
+		];
 
 		$response = wp_safe_remote_request( $url, $options );
 

--- a/includes/class-client.php
+++ b/includes/class-client.php
@@ -291,7 +291,7 @@ class ConstantContact_Client {
 			/**
 			 * Sets the HTTP timeout, in seconds, for the request.
 			 *
-			 * @since NEXT
+			 * @since 2.20.0
 			 *
 			 * @param int    30           The timeout limit, in seconds. Defaults to 30.
 			 * @param string $request_url The request URL.
@@ -331,7 +331,7 @@ class ConstantContact_Client {
 			/**
 			 * Sets the HTTP timeout, in seconds, for the request.
 			 *
-			 * @since NEXT
+			 * @since 2.20.0
 			 *
 			 * @param int    30           The timeout limit, in seconds. Defaults to 30.
 			 * @param string $request_url The request URL.
@@ -372,7 +372,7 @@ class ConstantContact_Client {
 			/**
 			 * Sets the HTTP timeout, in seconds, for the request.
 			 *
-			 * @since NEXT
+			 * @since 2.20.0
 			 *
 			 * @param int    30           The timeout limit, in seconds. Defaults to 30.
 			 * @param string $request_url The request URL.
@@ -413,7 +413,7 @@ class ConstantContact_Client {
 			/**
 			 * Sets the HTTP timeout, in seconds, for the request.
 			 *
-			 * @since NEXT
+			 * @since 2.20.0
 			 *
 			 * @param int    30           The timeout limit, in seconds. Defaults to 30.
 			 * @param string $request_url The request URL.


### PR DESCRIPTION
# Handles

[CON-541](https://app.clickup.com/t/9011385391/CON-541)

# Description

This PR adds changes inspired by the GravityForms Constant Contact addon around requests, including specifying timeout values, in case timeouts are providing to be an issue.

It also adds in a recursive `$this->refresh_token()` call inside the `refresh_token()` method, in cases where we should still have a valid refresh token available, to acquire fresh access tokens. This adds on to previously contributed changes.