### PR TITLE
Fix/con 540 race condition review

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -209,12 +209,6 @@ class ConstantContact_Admin {
 					}
 					echo wp_kses( '</ul>', [ 'ul' => [] ] );
 				}
-
-				if ( constant_contact_maybe_show_cron_notification() ) {
-				?>
-				<div class="ctct-status ctct-cron-status" title="<?php esc_attr_e( 'It looks like you have DISABLE_WP_CRON enabled. Constant Contact Forms relies on it to keep access tokens refreshed. You may see functionality issues if you do not have any manually configured cron jobs on your hosting server.', 'constant-contact-forms' ); ?>"><?php esc_html_e( 'WP CRON Disabled', 'constant-contact-forms' ); ?></div>
-				<?php
-				}
 				?>
 				<a href="edit.php?post_type=ctct_forms&page=ctct_options_connect" class="ctct-status ctct-<?php echo esc_attr( $api_status ); ?>" title="<?php echo esc_attr( $connect_alt ); ?>">
 					<?php echo esc_html( $connect_title ); ?>

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -286,18 +286,23 @@ class ConstantContact_API {
 	 */
 	public function acquire_access_token(): bool {
 
+		// Don't try anything on Heartbeat API
 		if ( ! empty( $_POST['action'] ) && 'heartbeat' === sanitize_text_field( $_POST['action'] ) ) {
 			return false;
 		}
 
+		// Don't try anything if intentionally disconnecting.
 		if ( ! empty( $_POST['ctct-disconnect'] ) && 'true' === sanitize_text_field( $_POST['ctct-disconnect'] ) ) {
 			return false;
 		}
+
+		// Don't try anything if we don't have options as a whole.
 		$options = get_option( 'ctct_options_settings' );
 		if ( empty( $options ) ) {
 			return false;
 		}
 
+		// Don't try anything if we don't have the state/authcode value.
 		if ( empty( $options['_ctct_form_state_authcode'] ) ) {
 			return false;
 		}

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -253,8 +253,9 @@ class ConstantContact_API {
 		$threshold   = $current - $issued_time;
 		// Check if we should attempt a refresh, beyond just cron checks.
 		if ( $issued_time > 0 && $threshold >= 82800 ) {
-			constant_contact_maybe_log_it( 'API', 'Attempting refresh in get_api_token.' );
-			if ( false === get_option( 'ctct_refreshing_token' ) ) {
+			if ( 'false' === get_option( 'ctct_refreshing_token' ) ) {
+				constant_contact_maybe_log_it( 'API', 'Attempting refresh in get_api_token.' );
+
 				// This should not be reached constantly. Once we have a new token,
 				// the threshold won't be within time.
 				// This method is more readily called than potential cron requests, so
@@ -412,7 +413,7 @@ class ConstantContact_API {
 		}
 
 		constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh token triggered' );
-		update_option( 'ctct_refreshing_token', true, false );
+		update_option( 'ctct_refreshing_token', 'true', false );
 
 		// Create full request URL
 		$body = [
@@ -480,7 +481,7 @@ class ConstantContact_API {
 			$status['reason']  = 'refreshed';
 		}
 
-		update_option( 'ctct_refreshing_token', false, false );
+		update_option( 'ctct_refreshing_token', 'false', false );
 		return $status;
 	}
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -446,7 +446,7 @@ class ConstantContact_API {
 		if ( false === $result ) {
 			constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh error occurred' );
 			if ( ! empty( $this->last_error ) ) {
-				constant_contact_maybe_log_it( 'Refresh Token:', 'Error: ' . $this->last_error );
+				constant_contact_maybe_log_it( 'Refresh Token:', 'Overall error: ' . $this->last_error );
 			}
 
 			$failures ++;

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -253,7 +253,7 @@ class ConstantContact_API {
 		$threshold   = $current - $issued_time;
 		// Check if we should attempt a refresh, beyond just cron checks.
 		if ( $issued_time > 0 && $threshold >= 82800 ) {
-
+			constant_contact_maybe_log_it( 'API', 'Attempting refresh in get_api_token.' );
 			if ( false === get_option( 'ctct_refreshing_token' ) ) {
 				// This should not be reached constantly. Once we have a new token,
 				// the threshold won't be within time.

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -547,8 +547,10 @@ class ConstantContact_API {
 
 	/**
 	 * Make sure we don't over-do API requests, helper method to check if we're connected.
-	 * @return boolean If connected.
+	 *
 	 * @since 1.0.0
+	 *
+	 * @return boolean If connected.
 	 */
 	public function is_connected() {
 		static $token = null;

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -567,7 +567,7 @@ class ConstantContact_API {
 	 * Execute our API request for token acquisition.
 	 *
 	 * @since 2.0.0
-	 * @since NEXT Added request type parameter.
+	 * @since 2.20.0 Added request type parameter.
 	 *
 	 * @param string $url          URL to make request to.
 	 * @param array  $options      Request options.

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -261,8 +261,8 @@ class ConstantContact_API {
 				// hopefully we're more actively refreshed.
 				$result = $this->refresh_token();
 
-				if ( ! $result['success'] && $result['reason'] === 'expired' ) {
-					constant_contact_maybe_log_it( 'API', 'Refresh token attempt failed in get_api_token.' );
+				if ( ! $result['success'] && $result['reason'] ) {
+					constant_contact_maybe_log_it( 'API', 'Refresh token attempt failed in get_api_token. ' . $result['reason'] );
 					$token = ''; // Reset to default from this method.
 				}
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -473,28 +473,6 @@ class ConstantContact_API {
 	}
 
 	/**
-	 * Check if our current access token is expired.
-	 * Based on access token issued timestamp + expires in timestamp and current time.
-	 * @return bool
-	 * @since 2.2.0
-	 */
-	private function access_token_maybe_expired() {
-
-		$issued_time = get_option( 'ctct_access_token_timestamp', '' );
-		if ( empty( $issued_time ) ) {
-			// It's not expired because it doesn't exist.
-			// This should be filled in by now though.
-			return false;
-		}
-
-		$current_time    = time();
-		$expiration_time = (int) $issued_time + (int) $this->expires_in;
-
-		// If we're currently above the expiration time, we're expired.
-		return $current_time >= $expiration_time;
-	}
-
-	/**
 	 * Generate the URL an account owner would use to allow your app
 	 * to access their account.
 	 * After visiting the URL, the account owner is prompted to log in and allow your app to access their account.

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -362,6 +362,10 @@ class ConstantContact_API {
 		$result = $this->exec( $url, $options, 'access' );
 
 		if ( false === $result ) {
+			constant_contact_maybe_log_it( 'Access Token:', 'Authentication to get access token error occurred' );
+			if ( ! empty( $this->last_error ) ) {
+				constant_contact_maybe_log_it( 'Access Token:', 'Error: ' . $this->last_error );
+			}
 			constant_contact_set_needs_manual_reconnect( 'true' );
 		} else {
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -677,7 +677,12 @@ class ConstantContact_API {
 			try {
 				$acct_data = $this->cc()->get_account_info();
 				if ( array_key_exists( 'error_key', $acct_data ) && 'unauthorized' === $acct_data['error_key'] ) {
-					$this->refresh_token();
+					constant_contact_maybe_log_it( 'API', 'Re-attempting account info request.' );
+					$status = $this->refresh_token();
+
+					if ( ! $status['success'] ) {
+						constant_contact_maybe_log_it( 'API', 'Account info refresh request failed. Reason: ' . $status['reason'] );
+					}
 
 					$acct_data = $this->cc()->get_account_info();
 				}
@@ -720,7 +725,12 @@ class ConstantContact_API {
 			try {
 				$contacts = $this->cc()->get_contacts();
 				if ( array_key_exists( 'error_key', $contacts ) && 'unauthorized' === $contacts['error_key'] ) {
-					$this->refresh_token();
+					constant_contact_maybe_log_it( 'API', 'Re-attempting get contacts request.' );
+					$status = $this->refresh_token();
+
+					if ( ! $status['success'] ) {
+						constant_contact_maybe_log_it( 'API', 'Get contacts refresh request failed. Reason: ' . $status['reason'] );
+					}
 
 					$contacts = $this->cc()->get_contacts();
 				}
@@ -776,9 +786,15 @@ class ConstantContact_API {
 				unset( $new_contact['ctct-instance'] );
 			}
 
+			constant_contact_maybe_log_it( 'API', 'Attempting contact request.' );
 			$return_contact = $this->create_update_contact( $list, $email, $new_contact, $form_id );
 			if ( array_key_exists( 'error_key', $return_contact ) && 'unauthorized' === $return_contact['error_key'] ) {
-				$this->refresh_token();
+				constant_contact_maybe_log_it( 'API', 'Re-attempting contact request.' );
+				$status = $this->refresh_token();
+
+				if ( ! $status['success'] ) {
+					constant_contact_maybe_log_it( 'API', 'Add contact refresh request failed. Reason: ' . $status['reason'] );
+				}
 
 				$return_contact = $this->create_update_contact( $list, $email, $new_contact, $form_id );
 				if ( array_key_exists( 'error_key', $return_contact ) ) {
@@ -1059,7 +1075,12 @@ class ConstantContact_API {
 				$lists = $results['lists'] ?? [];
 
 				if ( array_key_exists( 'error_key', $results ) && 'unauthorized' === $results['error_key'] ) {
-					$this->refresh_token();
+					constant_contact_maybe_log_it( 'API', 'Re-attempting get lists request.' );
+					$status = $this->refresh_token();
+
+					if ( ! $status['success'] ) {
+						constant_contact_maybe_log_it( 'API', 'Get list refresh request failed. Reason: ' . $status['reason'] );
+					}
 
 					$results = $this->cc()->get_lists();
 					$lists   = $results['lists'] ?? [];
@@ -1164,7 +1185,12 @@ class ConstantContact_API {
 			try {
 				$list = $this->cc()->get_list( $id );
 				if ( array_key_exists( 'error_key', $list ) && 'unauthorized' === $list['error_key'] ) {
-					$this->refresh_token();
+					constant_contact_maybe_log_it( 'API', 'Re-attempting get single list request.' );
+					$status = $this->refresh_token();
+
+					if ( ! $status['success'] ) {
+						constant_contact_maybe_log_it( 'API', 'Get single list refresh request failed. Reason: ' . $status['reason'] );
+					}
 
 					$list = $this->cc()->get_list( $id );
 				}
@@ -1210,7 +1236,12 @@ class ConstantContact_API {
 			try {
 				$list = $this->cc()->get_list( esc_attr( $new_list['id'] ) );
 				if ( array_key_exists( 'error_key', $list ) && 'unauthorized' === $list['error_key'] ) {
-					$this->refresh_token();
+					constant_contact_maybe_log_it( 'API', 'Re-attempting add list request.' );
+					$status = $this->refresh_token();
+
+					if ( ! $status['success'] ) {
+						constant_contact_maybe_log_it( 'API', 'Add list refresh request failed. Reason: ' . $status['reason'] );
+					}
 
 					$list = $this->cc()->get_list( esc_attr( $new_list['id'] ) );
 				}
@@ -1295,7 +1326,12 @@ class ConstantContact_API {
 
 			$return_list = $this->cc()->update_list( $list );
 			if ( array_key_exists( 'error_key', $return_list ) && 'unauthorized' === $return_list['error_key'] ) {
-				$this->refresh_token();
+				constant_contact_maybe_log_it( 'API', 'Re-attempting update list request.' );
+				$status = $this->refresh_token();
+
+				if ( ! $status['success'] ) {
+					constant_contact_maybe_log_it( 'API', 'Update list refresh request failed. Reason: ' . $status['reason'] );
+				}
 				$return_list = $this->cc()->update_list( $list );
 			}
 		} catch ( Exception $ex ) {
@@ -1333,7 +1369,12 @@ class ConstantContact_API {
 		try {
 			$list = $this->cc()->delete_list( $updated_list['id'] );
 			if ( array_key_exists( 'error_key', $list ) && 'unauthorized' === $list['error_key'] ) {
-				$this->refresh_token();
+				constant_contact_maybe_log_it( 'API', 'Re-attempting delete list request.' );
+				$status = $this->refresh_token();
+
+				if ( ! $status['success'] ) {
+					constant_contact_maybe_log_it( 'API', 'Delete list refresh request failed. Reason: ' . $status['reason'] );
+				}
 				$list = $this->cc()->delete_list( $updated_list['id'] );
 			}
 		} catch ( Exception $ex ) {

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -252,20 +252,23 @@ class ConstantContact_API {
 		$threshold   = $current - $issued_time;
 		// Check if we should attempt a refresh, beyond just cron checks.
 		if ( $issued_time > 0 && $threshold >= 82800 ) {
-			// This should not be reached constantly. Once we have a new token,
-			// the threshold won't be within time.
-			// This method is more readily called than potential cron requests, so
-			// hopefully we're more actively refreshed.
-			$result = $this->refresh_token();
 
-			if ( ! $result['success'] && $result['reason'] === 'expired' ) {
-				constant_contact_maybe_log_it( 'API', 'Refresh token attempt failed in get_api_token.' );
-				$token = ''; // Reset to default from this method.
-			}
+			if ( false === get_option( 'ctct_refreshing_token' ) ) {
+				// This should not be reached constantly. Once we have a new token,
+				// the threshold won't be within time.
+				// This method is more readily called than potential cron requests, so
+				// hopefully we're more actively refreshed.
+				$result = $this->refresh_token();
 
-			if ( $result['success'] ) {
-				// Should be new access token.
-				$token = constant_contact()->get_connect()->e_get( '_ctct_access_token' );
+				if ( ! $result['success'] && $result['reason'] === 'expired' ) {
+					constant_contact_maybe_log_it( 'API', 'Refresh token attempt failed in get_api_token.' );
+					$token = ''; // Reset to default from this method.
+				}
+
+				if ( $result['success'] ) {
+					// Should be new access token.
+					$token = constant_contact()->get_connect()->e_get( '_ctct_access_token' );
+				}
 			}
 		}
 
@@ -402,6 +405,7 @@ class ConstantContact_API {
 		}
 
 		constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh token triggered' );
+		update_option( 'ctct_refreshing_token', true, false );
 
 		// Create full request URL
 		$body = [
@@ -464,6 +468,7 @@ class ConstantContact_API {
 			$status['reason']  = 'refreshed';
 		}
 
+		update_option( 'ctct_refreshing_token', false, false );
 		return $status;
 	}
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -155,7 +155,6 @@ class ConstantContact_API {
 		$this->scopes = array_flip( $this->valid_scopes );
 
 		add_action( 'init', [ $this, 'ctct_init' ] );
-		add_action( 'ctct_refresh_token_job', [ $this, 'refresh_token' ] );
 		add_action( 'ctct_access_token_acquired', [ $this, 'clear_missed_api_requests' ] );
 	}
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -13,7 +13,6 @@
 /**
  * Powers connection between site and Constant Contact API.
  *
- * @todo Test RefreshToken Cron Job
  * @since 1.0.0
  */
 class ConstantContact_API {
@@ -217,39 +216,6 @@ class ConstantContact_API {
 			$success = $this->acquire_access_token();
 			if ( $success ) {
 				update_option( 'ctct_access_token_timestamp', time() );
-			}
-		}
-
-		// Future API work. Perhaps a `$this->access_token_maybe_expired()` check here.
-		// Keep frequency of `init` hook in mind.
-		// Would also remove need to check for DISABLE_WP_CRON later.
-
-		// custom scheduling based on the expiry time returned with access token.
-		add_filter(
-			'cron_schedules',
-			function ( $schedules ) {
-				$schedules['pkce_expiry'] = [
-					'interval' => 82800, // refreshing token before 1 hour of expiry.
-					'display'  => esc_html__( 'Constant Contact token expiry', 'constant-contact-forms' ),
-				];
-
-				return $schedules;
-			}
-		);
-
-		if ( ! empty( $this->expires_in ) ) {
-			if ( ! wp_next_scheduled( 'ctct_refresh_token_job' ) ) { // if it hasn't been scheduled
-				$result = wp_schedule_event( time(), 'pkce_expiry', 'ctct_refresh_token_job' ); // schedule it
-				$success = ( false === $result ) ? 'no' : 'yes';
-				constant_contact_maybe_log_it( 'Cron scheduled: ', $success );
-			}
-		} else {
-			wp_unschedule_hook( 'ctct_refresh_token_job' );
-		}
-
-		if ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON ) {
-			if ( $this->access_token_maybe_expired() ) {
-				$this->refresh_token();
 			}
 		}
 	}

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -214,6 +214,7 @@ class ConstantContact_API {
 		) {
 			$success = $this->acquire_access_token();
 			if ( $success ) {
+				// @todo maybe offset by 1min earlier?
 				update_option( 'ctct_access_token_timestamp', time() );
 			}
 		}

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -325,6 +325,8 @@ class ConstantContact_API {
 
 			return false;
 		}
+
+		constant_contact_maybe_log_it( 'API', 'Access token triggered' );
 		// Create full request URL
 		$body = [
 			'client_id'    => $this->client_api_key,

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -440,6 +440,11 @@ class ConstantContact_API {
 		$result = $this->exec( $url, $options, 'refresh' );
 
 		if ( false === $result ) {
+			constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh error occurred' );
+			if ( ! empty( $this->last_error ) ) {
+				constant_contact_maybe_log_it( 'Refresh Token:', 'Error: ' . $this->last_error );
+			}
+
 			$failures ++;
 			update_option( 'ctct_refresh_failures', $failures );
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -579,7 +579,7 @@ class ConstantContact_API {
 		$this->last_error  = '';
 		$this->status_code = 0;
 
-		constant_contact_maybe_log_it( 'Exec: acquire ', $request_type );
+		constant_contact_maybe_log_it( 'Exec: Acquiring ', $request_type );
 
 		if ( ! is_wp_error( $response ) ) {
 			if ( empty( $response['body'] ) ) {

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -583,6 +583,7 @@ class ConstantContact_API {
 
 		if ( ! is_wp_error( $response ) ) {
 			if ( empty( $response['body'] ) ) {
+				$this->last_error = implode( ":", $response['response'] );
 				constant_contact_maybe_log_it(
 					'Response error: ', implode( ":", $response['response'] )
 				);
@@ -591,6 +592,7 @@ class ConstantContact_API {
 			$data            = json_decode( $response['body'], true );
 			$json_last_error = json_last_error();
 			if ( JSON_ERROR_NONE !== $json_last_error ) {
+				$this->last_error = json_last_error_msg();
 				constant_contact_maybe_log_it( 'JSON error: ', json_last_error_msg() );
 			}
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -359,7 +359,7 @@ class ConstantContact_API {
 		];
 
 		// This will be either true or false.
-		$result = $this->exec( $url, $options );
+		$result = $this->exec( $url, $options, 'access' );
 
 		if ( false === $result ) {
 			constant_contact_set_needs_manual_reconnect( 'true' );
@@ -437,7 +437,7 @@ class ConstantContact_API {
 			'timeout' => apply_filters( 'http_request_timeout', 30, $url )
 		];
 
-		$result = $this->exec( $url, $options );
+		$result = $this->exec( $url, $options, 'refresh' );
 
 		if ( false === $result ) {
 			$failures ++;
@@ -554,18 +554,23 @@ class ConstantContact_API {
 	/**
 	 * Execute our API request for token acquisition.
 	 *
-	 * @param string $url     URL to make request to.
-	 * @param array  $options Request options.
+	 * @since 2.0.0
+	 * @since NEXT Added request type parameter.
+	 *
+	 * @param string $url          URL to make request to.
+	 * @param array  $options      Request options.
+	 * @param string $request_type Whether it's initial access or refresh request.
 	 *
 	 * @return bool
 	 * @throws Exception
-	 * @since 2.0.0
 	 */
-	private function exec( $url, $options ): bool {
+	private function exec( $url, $options, $request_type = '' ): bool {
 		$response = wp_safe_remote_post( $url, $options );
 
 		$this->last_error  = '';
 		$this->status_code = 0;
+
+		constant_contact_maybe_log_it( 'Exec: acquire ', $request_type );
 
 		if ( ! is_wp_error( $response ) ) {
 			if ( empty( $response['body'] ) ) {

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -587,6 +587,8 @@ class ConstantContact_API {
 		$this->last_error  = '';
 		$this->status_code = 0;
 
+		add_filter( 'constant_contact_force_logging', '__return_true' );
+
 		constant_contact_maybe_log_it( 'Exec: Acquiring ', $request_type );
 
 		if ( ! is_wp_error( $response ) ) {

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -789,7 +789,6 @@ class ConstantContact_API {
 				unset( $new_contact['ctct-instance'] );
 			}
 
-			constant_contact_maybe_log_it( 'API', 'Attempting contact request.' );
 			$return_contact = $this->create_update_contact( $list, $email, $new_contact, $form_id );
 			if ( array_key_exists( 'error_key', $return_contact ) && 'unauthorized' === $return_contact['error_key'] ) {
 				constant_contact_maybe_log_it( 'API', 'Re-attempting contact request.' );

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -387,6 +387,7 @@ class ConstantContact_Connect {
 		delete_option( '_ctct_expires_in' );
 		delete_option( 'ctct_maybe_needs_reconnected' );
 		delete_option( 'ctct_account_domain_hash' );
+		delete_option( 'ctct_refreshing_token' );
 
 		delete_option( 'CtctConstantContactcode_verifier' );
 		delete_option( 'CtctConstantContactState' );

--- a/includes/class-health.php
+++ b/includes/class-health.php
@@ -104,28 +104,12 @@ class ConstantContact_Health {
 					'value' => $expires_on,
 				],
 				[
-					'label' => esc_html__( 'DISABLE_WP_CRON Enabled?', 'constant-contact-forms' ),
-					'value' => ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON ) ? $yes : $no,
-				],
-				[
-					'label' => esc_html__( 'ALTERNATE_WP_CRON Enabled?', 'constant-contact-forms' ),
-					'value' => ( defined( 'ALTERNATE_WP_CRON' ) && ALTERNATE_WP_CRON ) ? $yes : $no,
-				],
-				[
 					'label' => esc_html__( 'CONSTANT_CONTACT_DEBUG_MAIL Enabled?', 'constant-contact-forms' ),
 					'value' => ( defined( 'CONSTANT_CONTACT_DEBUG_MAIL' ) && CONSTANT_CONTACT_DEBUG_MAIL ) ? $yes : $no,
 				],
 				[
 					'label' => esc_html__( 'Logs directory and file?', 'constant-contact-forms' ),
 					'value' => $logs_writeable,
-				],
-				[
-					'label' => esc_html__( 'Token refresh cron scheduled?', 'constant-contact-forms' ),
-					'value' => ( wp_next_scheduled( 'ctct_refresh_token_job' ) ) ? $yes : $no,
-				],
-				[
-					'label' => esc_html__( 'Cron check', 'constant-contact-forms' ),
-					'value' => $this->cron_spawn(),
 				],
 				[
 					'label' => esc_html__( 'reCAPTCHA Status', 'constant-contact-forms' ),
@@ -151,65 +135,5 @@ class ConstantContact_Health {
 		];
 
 		return $debug_info;
-	}
-
-	/**
-	 * Commission a cron job to check on server status.
-	 *
-	 * @since 2.3.0
-	 *
-	 * @return string
-	 */
-	public function cron_spawn(): string {
-
-		global $wp_version;
-
-		if ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON ) {
-			/* Translators: Placeholder will be a timestamp for the current time. */
-			return sprintf( esc_html__( 'The DISABLE_WP_CRON constant is set to true as of %1$s. WP-Cron is disabled and will not run.', 'constant-contact-forms' ), current_time( 'm/d/Y g:i:s a' ) );
-		}
-
-		if ( defined( 'ALTERNATE_WP_CRON' ) && ALTERNATE_WP_CRON ) {
-			/* Translators: Placeholder will be a timestamp for the current time. */
-			return sprintf( esc_html__( 'The ALTERNATE_WP_CRON constant is set to true as of %1$s. This plugin cannot determine the status of your WP-Cron system.', 'constant-contact-forms' ), current_time( 'm/d/Y g:i:s a' ) );
-		}
-
-		$sslverify     = version_compare( $wp_version, 4.0, '<' );
-		$doing_wp_cron = sprintf( '%.22F', microtime( true ) );
-
-		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Filters defined in WP Core.
-		/* This filter is documented in wp-includes/cron.php */
-		$cron_request = apply_filters(
-			'cron_request',
-			[
-				'url'  => site_url( 'wp-cron.php?doing_wp_cron=' . $doing_wp_cron ),
-				'key'  => $doing_wp_cron,
-				'args' => [
-					'timeout'   => 3,
-					'blocking'  => true,
-					'sslverify' => apply_filters( 'https_local_ssl_verify', $sslverify ),
-				],
-			]
-		);
-		// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-
-		$cron_request['args']['blocking'] = true;
-
-		$result        = wp_remote_post( $cron_request['url'], $cron_request['args'] );
-		$response_code = wp_remote_retrieve_response_code( $result );
-
-		if ( is_wp_error( $result ) ) {
-			return $result->get_error_message();
-		}
-
-		if ( 300 <= $response_code ) {
-			return sprintf(
-			/* Translators: Placeholder will be an HTTP response code. */
-				esc_html__( 'Unexpected HTTP response code: %1$s', 'constant-contact-forms' ),
-				(int) $response_code
-			);
-		}
-
-		return esc_html__( 'Cron spawn ok', 'constant-contact-forms' );
 	}
 }

--- a/includes/class-process-form.php
+++ b/includes/class-process-form.php
@@ -539,7 +539,7 @@ class ConstantContact_Process_Form {
 						}
 					} else {
 						// Only email if we have a successful API request.
-						constant_contact()->get_mail()->submit_form_values( $return['values'] ); // Emails but doesn't schedule cron.
+						constant_contact()->get_mail()->submit_form_values( $return['values'] );
 					}
 				} else {
 					// We have at least one list, but are not considered connected.

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -450,6 +450,10 @@ class ConstantContact_Settings {
 	protected function register_fields_optin() {
 		$cmb = new_cmb2_box( $this->get_cmb_args( 'optin' ) );
 
+		if ( empty( $_GET['page'] ) || 'ctct_options_settings_optin' !== $_GET['page'] ) {
+			return;
+		}
+
 		if ( constant_contact()->get_api()->is_connected() ) {
 			$lists     = constant_contact()->get_builder()->get_lists();
 			$woo_lists = [

--- a/includes/class-uninstall.php
+++ b/includes/class-uninstall.php
@@ -64,6 +64,7 @@ class ConstantContact_Uninstall {
 			'ctct_log_suffix',
 			'ctct_refresh_failures',
 			'ctct_account_domain_hash',
+			'ctct_refreshing_token',
 			Constant_Contact::$activated_date_option,
 			ConstantContact_Notifications::$dismissed_notices_option,
 			ConstantContact_Notifications::$review_dismissed_option,

--- a/includes/class-uninstall.php
+++ b/includes/class-uninstall.php
@@ -140,6 +140,7 @@ class ConstantContact_Uninstall {
 	private function get_cron_hook_names() {
 		$default_cron_hooks = [
 			'ctct_schedule_form_opt_in',
+			'ctct_refresh_token_job',
 		];
 
 		/**

--- a/includes/notification-logic.php
+++ b/includes/notification-logic.php
@@ -198,27 +198,6 @@ function constant_contact_maybe_display_disconnect_reconnect_notice(): bool {
 	return constant_contact_get_needs_manual_reconnect();
 }
 
-/**
- * Maybe show notification regarding `DISABLE_WP_CRON`.
- * @return bool
- * @since 2.2.0
- */
-function constant_contact_maybe_show_cron_notification(): bool {
-	if ( ! current_user_can( 'manage_options' ) ) {
-		return false;
-	}
-
-	if ( ! constant_contact()->is_constant_contact() ) {
-		return false;
-	}
-
-	if ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON ) {
-		return true;
-	}
-
-	return false;
-}
-
 function constant_contact_maybe_show_update_available_notification(): bool {
 	if ( ! current_user_can( 'manage_options' ) ) {
 		return false;


### PR DESCRIPTION
# Handles

[CON-540](https://app.clickup.com/t/9011385391/CON-540)

# Description

1. Removes WP Cron integration in favor of more real time requests including refresh checks.
2. Increases our own logging in more places for more coverage of ongoing requests.
3. Adds gated API checks inside get access token method. While we're potentially refreshing, set a flag that prevents subsequent requests from potentially also trying to refresh.
4. Adds current request type to our `exec()` method. Only used for initial token acquisition and refreshes.
5. Increased usage of `last_error` property to help unearth potential missed errors.
6. Prevent potential API requests on screens that we don't need account information for.