### PR TITLE
make sure we have date parts before we set the anniversary property

### DIFF
--- a/includes/class-mail.php
+++ b/includes/class-mail.php
@@ -154,10 +154,13 @@ class ConstantContact_Mail {
 		$lists        = $values['ctct-lists'] ?? [];
 		$lists        = $lists['value'] ?? [];
 		$args['list'] = is_array( $lists ) ? array_map( 'sanitize_text_field', $lists ) : sanitize_text_field( $lists );
-		$args['anniversary'] = [
-			'key' => 'anniversary',
-			'val' => $this->format_anniversary_date( $date_parts ),
-		];
+
+		if ( ! empty( $date_parts ) ) {
+			$args['anniversary'] = [
+				'key' => 'anniversary',
+				'val' => $this->format_anniversary_date( $date_parts ),
+			];
+		}
 		return constant_contact()->get_api()->add_contact( $args, $values['ctct-id']['value'] );
 	}
 


### PR DESCRIPTION
# Handles

[CON-546](https://app.clickup.com/t/9011385391/CON-546)

# Description

We were unintentionally including the anniversary index/property even if we did not have date values to use with it. We will check if our date_parts array is empty first.