### PR TITLE
Remove redundant minimum version checks at the code level.

### DIFF
--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -364,11 +364,6 @@ class Constant_Contact {
 		$this->url      = plugin_dir_url( __FILE__ );
 		$this->path     = plugin_dir_path( __FILE__ );
 
-		if ( ! $this->meets_php_requirements() ) {
-			add_action( 'admin_notices', [ $this, 'minimum_version' ] );
-			return;
-		}
-
 		// Load our plugin and our libraries.
 		$this->plugin_classes();
 		$this->admin_plugin_classes();
@@ -387,15 +382,6 @@ class Constant_Contact {
 
 		// Include deprecated functions.
 		self::include_file( 'deprecated', false );
-	}
-
-	/**
-	 * Display an admin notice for users on less than PHP 5.4.x.
-	 *
-	 * @since 1.0.1
-	 */
-	public function minimum_version(): void {
-		echo '<div id="message" class="notice is-dismissible error"><p>' . esc_html__( 'Constant Contact Forms requires PHP 7.4 or higher. Your hosting provider or website administrator should be able to assist in updating your PHP version.', 'constant-contact-forms' ) . '</p></div>';
 	}
 
 	/**
@@ -453,11 +439,6 @@ class Constant_Contact {
 	 * @return void
 	 */
 	public function hooks(): void {
-		if ( ! $this->meets_php_requirements() ) {
-			add_action( 'admin_notices', [ $this, 'minimum_version' ] );
-			return;
-		}
-
 		add_action( 'init', [ $this, 'init' ] );
 		add_action( 'widgets_init', [ $this, 'widgets' ] );
 		add_filter( 'body_class', [ $this, 'body_classes' ] );
@@ -494,10 +475,6 @@ class Constant_Contact {
 	 */
 	public function deactivate(): void {
 
-		if ( ! $this->meets_php_requirements() ) {
-			return;
-		}
-
 		// Clear out connection data when deactivating plugin.
 		delete_option( 'ctct_access_token' );
 		delete_option( '_ctct_access_token' );
@@ -524,17 +501,6 @@ class Constant_Contact {
 	public function uninstall(): void {
 		$uninstaller = new ConstantContact_Uninstall();
 		$uninstaller->run();
-	}
-
-	/**
-	 * Whether or not we meet our minimal PHP requirements.
-	 *
-	 * @since 1.2.0
-	 *
-	 * @return bool
-	 */
-	public function meets_php_requirements() : bool {
-		return version_compare( PHP_VERSION, '7.4.0', '>=' );
 	}
 
 	/**

--- a/includes/class-block.php
+++ b/includes/class-block.php
@@ -35,22 +35,7 @@ class ConstantContact_Block {
 	public function __construct( object $plugin ) {
 		$this->plugin = $plugin;
 
-		if ( $this->meets_requirements() ) {
-			add_action( 'init', [ $this, 'register_blocks' ] );
-		}
-	}
-
-	/**
-	 * Check requirements.
-	 *
-	 * @author Eric Fuller
-	 * @since  1.5.0
-	 * @return bool
-	 */
-	private function meets_requirements() : bool {
-		global $wp_version;
-
-		return version_compare( $wp_version, '5.0.0' ) >= 0;
+		add_action( 'init', [ $this, 'register_blocks' ] );
 	}
 
 	/**


### PR DESCRIPTION
# Handles
[CON-548](https://app.clickup.com/t/9011385391/CON-548)

## Description
This removes legacy PHP version requirements and WP requirements for block support.

