### PR TITLE
Fix/con 550 connection wording

### DIFF
--- a/assets/sass/_admin-toolbar.scss
+++ b/assets/sass/_admin-toolbar.scss
@@ -164,9 +164,13 @@
 		}
 
 		&.ctct-connected{
-
 			&::before{
 				background-color: variables.$color-green;
+			}
+		}
+		&.ctct-not-connected {
+			&::before {
+				background-color: variables.$color-chrome-yellow;
 			}
 		}
 	}

--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -27,7 +27,7 @@ $color-success: $color-green;
 
 // constant contact colors
 $color-sky-blue: #88c5e2;
-$color-chrome-yellow: #ffa901;
+$color-chrome-yellow: #ff9e1a;
 $color-prussian-blue: #0078c3;
 $color-cc-blue: #1a5285;
 $color-alt-silver: #efefee;

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -186,7 +186,12 @@ class ConstantContact_Admin {
 		$connect_title = esc_html__( 'Connected', 'constant-contact-forms' );
 		$connect_alt   = esc_html__( 'Your Constant Contact account is connected!', 'constant-contact-forms' );
 		$api_status    = esc_html( 'connected' );
-		if ( ! constant_contact()->get_api()->is_connected() || constant_contact_get_needs_manual_reconnect() ) {
+		if ( ! constant_contact()->get_api()->is_connected() ) {
+			$connect_title = esc_html__( 'Not connected', 'constant-contact-forms' );
+			$connect_alt   = esc_html__( 'Connect your account to start contact growth.', 'constant-contact-forms' );
+			$api_status    = esc_attr( 'not-connected' );
+		}
+		if ( constant_contact_get_needs_manual_reconnect() ) {
 			$connect_title = esc_html__( 'Disconnected', 'constant-contact-forms' );
 			$connect_alt   = esc_html__( 'Your Constant Contact account is not connected.', 'constant-contact-forms' );
 			$api_status    = esc_attr( 'disconnected' );


### PR DESCRIPTION
# Handles

[CON-550](https://app.clickup.com/t/9011385391/CON-550)

## Description

This PR adjusts the CTCT admin bar to read "not connected" when we don't have access tokens, but not in need of a reconnect from a previous connection.

It also uses an orange dot.