### PR TITLE
Feature/con 549 disconnects continued

### DIFF
--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -509,6 +509,8 @@ class Constant_Contact {
 		delete_option( 'ctct_auth_url' );
 		delete_option( 'ctct_key' );
 		delete_option( 'ctct_maybe_needs_reconnected' );
+		delete_option( 'ctct_acquiring_token' );
+		delete_option( 'ctct_refreshing_token' );
 		constant_contact_delete_option( '_ctct_form_state_authcode' );
 		wp_clear_scheduled_hook( 'ctct_refresh_token_job' );
 		wp_unschedule_hook( 'ctct_refresh_token_job' );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -198,6 +198,7 @@ class ConstantContact_API {
 								[ 'dismissible' => true ]
 							);
 						} );
+						add_filter( 'constant_contact_force_logging', '__return_true' );
 						constant_contact_maybe_log_it( 'API', 'Hashed domain mismatch. The following domain does not match the original connecting domain value: ' . esc_html( $account_domain['site'] ) );
 						constant_contact()->get_connect()->force_disconnect();
 						return false;
@@ -254,6 +255,7 @@ class ConstantContact_API {
 		// Check if we should attempt a refresh, beyond just cron checks.
 		if ( $issued_time > 0 && $threshold >= 82800 ) {
 			if ( 'false' === get_option( 'ctct_refreshing_token' ) ) {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'API', 'Attempting refresh in get_api_token.' );
 
 				// This should not be reached constantly. Once we have a new token,
@@ -263,6 +265,7 @@ class ConstantContact_API {
 				$result = $this->refresh_token();
 
 				if ( ! $result['success'] && $result['reason'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Refresh token attempt failed in get_api_token. ' . $result['reason'] );
 					$token = ''; // Reset to default from this method.
 				}
@@ -315,6 +318,7 @@ class ConstantContact_API {
 		if ( empty( $parsed_code_state[0] ) || empty( $parsed_code_state[1] ) ) {
 			$this->status_code = 0;
 			$this->last_error  = 'Invalid state or auth code';
+			add_filter( 'constant_contact_force_logging', '__return_true' );
 			constant_contact_maybe_log_it( 'Error: ', $this->last_error );
 
 			return false;
@@ -328,11 +332,13 @@ class ConstantContact_API {
 		if ( ( $state ?? 'undefined' ) != $expected_state ) {
 			$this->status_code = 0;
 			$this->last_error  = 'state is not correct';
+			add_filter( 'constant_contact_force_logging', '__return_true' );
 			constant_contact_maybe_log_it( 'Error: ', $this->last_error );
 
 			return false;
 		}
 
+		add_filter( 'constant_contact_force_logging', '__return_true' );
 		constant_contact_maybe_log_it( 'API', 'Access token triggered' );
 		// Create full request URL
 		$body = [
@@ -368,8 +374,10 @@ class ConstantContact_API {
 		$result = $this->exec( $url, $options, 'access' );
 
 		if ( false === $result ) {
+			add_filter( 'constant_contact_force_logging', '__return_true' );
 			constant_contact_maybe_log_it( 'Access Token:', 'Authentication to get access token error occurred' );
 			if ( ! empty( $this->last_error ) ) {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'Access Token:', 'Error: ' . $this->last_error );
 			}
 			constant_contact_set_needs_manual_reconnect( 'true' );
@@ -417,6 +425,7 @@ class ConstantContact_API {
 			return $status;
 		}
 
+		add_filter( 'constant_contact_force_logging', '__return_true' );
 		constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh token triggered' );
 		update_option( 'ctct_refreshing_token', 'true', false );
 
@@ -450,8 +459,10 @@ class ConstantContact_API {
 		$result = $this->exec( $url, $options, 'refresh' );
 
 		if ( false === $result ) {
+			add_filter( 'constant_contact_force_logging', '__return_true' );
 			constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh error occurred' );
 			if ( ! empty( $this->last_error ) ) {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'Refresh Token:', 'Overall error: ' . $this->last_error );
 			}
 
@@ -462,14 +473,17 @@ class ConstantContact_API {
 			// Only require manual reconnect for invalid_grant (revoked/expired refresh
 			// token) or after 5 consecutive failures of any kind.
 			if ( false !== strpos( $this->last_error, 'invalid_grant' ) ) {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh token revoked (invalid_grant). Manual reconnect required.' );
 				constant_contact_set_needs_manual_reconnect( 'true' );
 				$status['reason'] = 'expired';
 			} elseif ( $failures >= 5 ) {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh failed ' . $failures . ' consecutive times. Manual reconnect required.' );
 				constant_contact_set_needs_manual_reconnect( 'true' );
 				$status['reason'] = 'max_retries_exceeded';
 			} else {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh failed (attempt ' . $failures . '/5). Will retry. Attempted at ' . current_datetime()->format( 'Y-n-d, H:i' ) );
 				$status['reason'] = 'transient_failure';
 				$this->refresh_token();
@@ -594,6 +608,7 @@ class ConstantContact_API {
 		if ( ! is_wp_error( $response ) ) {
 			if ( empty( $response['body'] ) ) {
 				$this->last_error = implode( ":", $response['response'] );
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it(
 					'Response error: ', implode( ":", $response['response'] )
 				);
@@ -603,6 +618,7 @@ class ConstantContact_API {
 			$json_last_error = json_last_error();
 			if ( JSON_ERROR_NONE !== $json_last_error ) {
 				$this->last_error = json_last_error_msg();
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'JSON error: ', json_last_error_msg() );
 			}
 
@@ -612,6 +628,7 @@ class ConstantContact_API {
 					$this->api_errors_admin_email();
 				}
 				$this->last_error = $data['error'] . ': ' . ( $data['error_description'] ?? 'Undefined' );
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'Error: ', $this->last_error );
 
 				return false;
@@ -652,6 +669,7 @@ class ConstantContact_API {
 		} else {
 			$this->status_code = 0;
 			$this->last_error  = $response->get_error_message();
+			add_filter( 'constant_contact_force_logging', '__return_true' );
 			constant_contact_maybe_log_it( 'Error: ', $this->last_error );
 		}
 
@@ -687,10 +705,12 @@ class ConstantContact_API {
 			try {
 				$acct_data = $this->cc()->get_account_info();
 				if ( array_key_exists( 'error_key', $acct_data ) && 'unauthorized' === $acct_data['error_key'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Re-attempting account info request.' );
 					$status = $this->refresh_token();
 
 					if ( ! $status['success'] ) {
+						add_filter( 'constant_contact_force_logging', '__return_true' );
 						constant_contact_maybe_log_it( 'API', 'Account info refresh request failed. Reason: ' . $status['reason'] );
 					}
 
@@ -735,10 +755,12 @@ class ConstantContact_API {
 			try {
 				$contacts = $this->cc()->get_contacts();
 				if ( array_key_exists( 'error_key', $contacts ) && 'unauthorized' === $contacts['error_key'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Re-attempting get contacts request.' );
 					$status = $this->refresh_token();
 
 					if ( ! $status['success'] ) {
+						add_filter( 'constant_contact_force_logging', '__return_true' );
 						constant_contact_maybe_log_it( 'API', 'Get contacts refresh request failed. Reason: ' . $status['reason'] );
 					}
 
@@ -798,10 +820,12 @@ class ConstantContact_API {
 
 			$return_contact = $this->create_update_contact( $list, $email, $new_contact, $form_id );
 			if ( array_key_exists( 'error_key', $return_contact ) && 'unauthorized' === $return_contact['error_key'] ) {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'API', 'Re-attempting contact request.' );
 				$status = $this->refresh_token();
 
 				if ( ! $status['success'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Add contact refresh request failed. Reason: ' . $status['reason'] );
 				}
 
@@ -1084,10 +1108,12 @@ class ConstantContact_API {
 				$lists = $results['lists'] ?? [];
 
 				if ( array_key_exists( 'error_key', $results ) && 'unauthorized' === $results['error_key'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Re-attempting get lists request.' );
 					$status = $this->refresh_token();
 
 					if ( ! $status['success'] ) {
+						add_filter( 'constant_contact_force_logging', '__return_true' );
 						constant_contact_maybe_log_it( 'API', 'Get list refresh request failed. Reason: ' . $status['reason'] );
 					}
 
@@ -1194,10 +1220,12 @@ class ConstantContact_API {
 			try {
 				$list = $this->cc()->get_list( $id );
 				if ( array_key_exists( 'error_key', $list ) && 'unauthorized' === $list['error_key'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Re-attempting get single list request.' );
 					$status = $this->refresh_token();
 
 					if ( ! $status['success'] ) {
+						add_filter( 'constant_contact_force_logging', '__return_true' );
 						constant_contact_maybe_log_it( 'API', 'Get single list refresh request failed. Reason: ' . $status['reason'] );
 					}
 
@@ -1245,10 +1273,12 @@ class ConstantContact_API {
 			try {
 				$list = $this->cc()->get_list( esc_attr( $new_list['id'] ) );
 				if ( array_key_exists( 'error_key', $list ) && 'unauthorized' === $list['error_key'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Re-attempting add list request.' );
 					$status = $this->refresh_token();
 
 					if ( ! $status['success'] ) {
+						add_filter( 'constant_contact_force_logging', '__return_true' );
 						constant_contact_maybe_log_it( 'API', 'Add list refresh request failed. Reason: ' . $status['reason'] );
 					}
 
@@ -1335,10 +1365,12 @@ class ConstantContact_API {
 
 			$return_list = $this->cc()->update_list( $list );
 			if ( array_key_exists( 'error_key', $return_list ) && 'unauthorized' === $return_list['error_key'] ) {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'API', 'Re-attempting update list request.' );
 				$status = $this->refresh_token();
 
 				if ( ! $status['success'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Update list refresh request failed. Reason: ' . $status['reason'] );
 				}
 				$return_list = $this->cc()->update_list( $list );
@@ -1378,10 +1410,12 @@ class ConstantContact_API {
 		try {
 			$list = $this->cc()->delete_list( $updated_list['id'] );
 			if ( array_key_exists( 'error_key', $list ) && 'unauthorized' === $list['error_key'] ) {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'API', 'Re-attempting delete list request.' );
 				$status = $this->refresh_token();
 
 				if ( ! $status['success'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Delete list refresh request failed. Reason: ' . $status['reason'] );
 				}
 				$list = $this->cc()->delete_list( $updated_list['id'] );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -290,6 +290,10 @@ class ConstantContact_API {
 	 */
 	public function acquire_access_token(): bool {
 
+		if ( 'false' !== get_option( 'ctct_acquiring_token' ) ) {
+			return false;
+		}
+
 		// Don't try anything on Heartbeat API
 		if ( ! empty( $_POST['action'] ) && 'heartbeat' === sanitize_text_field( $_POST['action'] ) ) {
 			return false;

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -290,7 +290,7 @@ class ConstantContact_API {
 	 */
 	public function acquire_access_token(): bool {
 
-		if ( 'false' !== get_option( 'ctct_acquiring_token' ) ) {
+		if ( 'false' !== get_option( 'ctct_acquiring_token', 'false' ) ) {
 			return false;
 		}
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -200,7 +200,8 @@ class ConstantContact_API {
 						} );
 						add_filter( 'constant_contact_force_logging', '__return_true' );
 						constant_contact_maybe_log_it( 'API', 'Hashed domain mismatch. The following domain does not match the original connecting domain value: ' . esc_html( $account_domain['site'] ) );
-						constant_contact()->get_connect()->force_disconnect();
+						// Temporarily skip actually disconnecting from this point in code.
+						constant_contact()->get_connect()->force_disconnect( true );
 						return false;
 					}
 				}

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -315,6 +315,8 @@ class ConstantContact_API {
 			return false;
 		}
 
+		update_option( 'ctct_acquiring_token', 'true', false );
+
 		$code_state = $options['_ctct_form_state_authcode'];
 
 		parse_str( $code_state, $parsed_code_state );
@@ -397,7 +399,7 @@ class ConstantContact_API {
 			constant_contact_set_needs_manual_reconnect( 'false' );
 		}
 
-
+		update_option( 'ctct_acquiring_token', 'false', false );
 		return $result;
 	}
 

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -395,6 +395,7 @@ class ConstantContact_Connect {
 		delete_option( '_ctct_expires_in' );
 		delete_option( 'ctct_maybe_needs_reconnected' );
 		delete_option( 'ctct_account_domain_hash' );
+		delete_option( 'ctct_acquiring_token' );
 		delete_option( 'ctct_refreshing_token' );
 
 		delete_option( 'CtctConstantContactcode_verifier' );

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -364,9 +364,15 @@ class ConstantContact_Connect {
 			return false;
 		}
 
+		// Cases where we may not have vendor loaded yet?
+		constant_contact()->load_libs();
+
 		if ( wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['ctct-admin-disconnect'] ) ), 'ctct-admin-disconnect' ) ) {
+			add_filter( 'constant_contact_force_logging', '__return_true' );
+			constant_contact_maybe_log_it( 'API', 'Manual disconnect' );
 			$this->force_disconnect();
 		} else {
+			add_filter( 'constant_contact_force_logging', '__return_true' );
 			constant_contact_maybe_log_it( 'Nonces', 'Account disconnection nonce failed to verify.' );
 		}
 		return true;

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -377,9 +377,17 @@ class ConstantContact_Connect {
 	 *
 	 * @since 2.19.0
 	 *
+	 * @param bool $skip_disconnect Whether or not to actually disconnect
 	 * @return bool
 	 */
-	public function force_disconnect() : bool {
+	public function force_disconnect( $skip_disconnect = false ) : bool {
+		add_filter( 'constant_contact_force_logging', '__return_true' );
+		constant_contact_maybe_log_it( 'API', 'Force disconnect reached' );
+
+		if ( $skip_disconnect ) {
+			return false;
+		}
+
 		delete_option( 'ctct_access_token' );
 		delete_option( '_ctct_access_token' );
 		delete_option( 'ctct_refresh_token' );


### PR DESCRIPTION
# Handles

[CON-549](https://app.clickup.com/t/9011385391/CON-549)

## Description

1. Adds a "acquiring access token" guardrail to prevent potential multiple requests quickly.
2. Adds continued extra logging as well as forced logging filtering to try and make sure we get the logs added.
3. Skips running `force_disconnect` temporarily for the domain/hash comparison, to see if we are managing to get to that point with unexpected frequency.
4. Fills in `delete_option` calls for various cases of intentional disconnect or deactivation.