### PR TITLE
Release2210 1

### DIFF
--- a/assets/sass/_admin-toolbar.scss
+++ b/assets/sass/_admin-toolbar.scss
@@ -164,9 +164,13 @@
 		}
 
 		&.ctct-connected{
-
 			&::before{
 				background-color: variables.$color-green;
+			}
+		}
+		&.ctct-not-connected {
+			&::before {
+				background-color: variables.$color-chrome-yellow;
 			}
 		}
 	}

--- a/assets/sass/_inputs.scss
+++ b/assets/sass/_inputs.scss
@@ -44,7 +44,6 @@
 				padding-left: 40px;
 			}
 		}
-
 	}
 
 	select {
@@ -58,15 +57,6 @@
 		color: variables.$color-red;
 		font-size: 0.85rem;
 		font-style: italic;
-	}
-
-	input.ctct-invalid {
-		background: variables.$color-white url( ../images/error.svg ) no-repeat;
-		background-color: color.adjust(variables.$color-error, $alpha: -0.98);
-		background-position: 8px 50%;
-		background-size: 24px;
-		border-color: variables.$color-error;
-		padding-left: 40px;
 	}
 
 	input.ctct-label-left,

--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -27,7 +27,7 @@ $color-success: $color-green;
 
 // constant contact colors
 $color-sky-blue: #88c5e2;
-$color-chrome-yellow: #ffa901;
+$color-chrome-yellow: #ff9e1a;
 $color-prussian-blue: #0078c3;
 $color-cc-blue: #1a5285;
 $color-alt-silver: #efefee;

--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -486,6 +486,8 @@ class Constant_Contact {
 		delete_option( 'ctct_auth_url' );
 		delete_option( 'ctct_key' );
 		delete_option( 'ctct_maybe_needs_reconnected' );
+		delete_option( 'ctct_acquiring_token' );
+		delete_option( 'ctct_refreshing_token' );
 		constant_contact_delete_option( '_ctct_form_state_authcode' );
 		wp_clear_scheduled_hook( 'ctct_refresh_token_job' );
 		wp_unschedule_hook( 'ctct_refresh_token_job' );

--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -364,11 +364,6 @@ class Constant_Contact {
 		$this->url      = plugin_dir_url( __FILE__ );
 		$this->path     = plugin_dir_path( __FILE__ );
 
-		if ( ! $this->meets_php_requirements() ) {
-			add_action( 'admin_notices', [ $this, 'minimum_version' ] );
-			return;
-		}
-
 		// Load our plugin and our libraries.
 		$this->plugin_classes();
 		$this->admin_plugin_classes();
@@ -387,15 +382,6 @@ class Constant_Contact {
 
 		// Include deprecated functions.
 		self::include_file( 'deprecated', false );
-	}
-
-	/**
-	 * Display an admin notice for users on less than PHP 5.4.x.
-	 *
-	 * @since 1.0.1
-	 */
-	public function minimum_version(): void {
-		echo '<div id="message" class="notice is-dismissible error"><p>' . esc_html__( 'Constant Contact Forms requires PHP 7.4 or higher. Your hosting provider or website administrator should be able to assist in updating your PHP version.', 'constant-contact-forms' ) . '</p></div>';
 	}
 
 	/**
@@ -453,11 +439,6 @@ class Constant_Contact {
 	 * @return void
 	 */
 	public function hooks(): void {
-		if ( ! $this->meets_php_requirements() ) {
-			add_action( 'admin_notices', [ $this, 'minimum_version' ] );
-			return;
-		}
-
 		add_action( 'init', [ $this, 'init' ] );
 		add_action( 'widgets_init', [ $this, 'widgets' ] );
 		add_filter( 'body_class', [ $this, 'body_classes' ] );
@@ -494,10 +475,6 @@ class Constant_Contact {
 	 */
 	public function deactivate(): void {
 
-		if ( ! $this->meets_php_requirements() ) {
-			return;
-		}
-
 		// Clear out connection data when deactivating plugin.
 		delete_option( 'ctct_access_token' );
 		delete_option( '_ctct_access_token' );
@@ -524,17 +501,6 @@ class Constant_Contact {
 	public function uninstall(): void {
 		$uninstaller = new ConstantContact_Uninstall();
 		$uninstaller->run();
-	}
-
-	/**
-	 * Whether or not we meet our minimal PHP requirements.
-	 *
-	 * @since 1.2.0
-	 *
-	 * @return bool
-	 */
-	public function meets_php_requirements() : bool {
-		return version_compare( PHP_VERSION, '7.4.0', '>=' );
 	}
 
 	/**

--- a/constant-contact-forms.php
+++ b/constant-contact-forms.php
@@ -12,7 +12,7 @@
  * Plugin Name: Constant Contact Forms for WordPress
  * Plugin URI:  https://www.constantcontact.com
  * Description: Be a better marketer. All it takes is Constant Contact email marketing.
- * Version:     2.20.0
+ * Version:     2.21.0
  * Author:      Constant Contact
  * Author URI:  https://www.constantcontact.com/index?pn=miwordpress
  * Requires PHP: 8.1
@@ -77,7 +77,7 @@ class Constant_Contact {
 	 * @since 1.0.0
 	 * @var string
 	 */
-	const VERSION = '2.20.0';
+	const VERSION = '2.21.0';
 
 	/**
 	 * URL of plugin directory.

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -186,7 +186,12 @@ class ConstantContact_Admin {
 		$connect_title = esc_html__( 'Connected', 'constant-contact-forms' );
 		$connect_alt   = esc_html__( 'Your Constant Contact account is connected!', 'constant-contact-forms' );
 		$api_status    = esc_html( 'connected' );
-		if ( ! constant_contact()->get_api()->is_connected() || constant_contact_get_needs_manual_reconnect() ) {
+		if ( ! constant_contact()->get_api()->is_connected() ) {
+			$connect_title = esc_html__( 'Not connected', 'constant-contact-forms' );
+			$connect_alt   = esc_html__( 'Connect your account to start contact growth.', 'constant-contact-forms' );
+			$api_status    = esc_attr( 'not-connected' );
+		}
+		if ( constant_contact_get_needs_manual_reconnect() ) {
 			$connect_title = esc_html__( 'Disconnected', 'constant-contact-forms' );
 			$connect_alt   = esc_html__( 'Your Constant Contact account is not connected.', 'constant-contact-forms' );
 			$api_status    = esc_attr( 'disconnected' );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -198,8 +198,10 @@ class ConstantContact_API {
 								[ 'dismissible' => true ]
 							);
 						} );
+						add_filter( 'constant_contact_force_logging', '__return_true' );
 						constant_contact_maybe_log_it( 'API', 'Hashed domain mismatch. The following domain does not match the original connecting domain value: ' . esc_html( $account_domain['site'] ) );
-						constant_contact()->get_connect()->force_disconnect();
+						// Temporarily skip actually disconnecting from this point in code.
+						constant_contact()->get_connect()->force_disconnect( true );
 						return false;
 					}
 				}
@@ -254,6 +256,7 @@ class ConstantContact_API {
 		// Check if we should attempt a refresh, beyond just cron checks.
 		if ( $issued_time > 0 && $threshold >= 82800 ) {
 			if ( 'false' === get_option( 'ctct_refreshing_token' ) ) {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'API', 'Attempting refresh in get_api_token.' );
 
 				// This should not be reached constantly. Once we have a new token,
@@ -263,6 +266,7 @@ class ConstantContact_API {
 				$result = $this->refresh_token();
 
 				if ( ! $result['success'] && $result['reason'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Refresh token attempt failed in get_api_token. ' . $result['reason'] );
 					$token = ''; // Reset to default from this method.
 				}
@@ -286,6 +290,10 @@ class ConstantContact_API {
 	 */
 	public function acquire_access_token(): bool {
 
+		if ( 'false' !== get_option( 'ctct_acquiring_token', 'false' ) ) {
+			return false;
+		}
+
 		// Don't try anything on Heartbeat API
 		if ( ! empty( $_POST['action'] ) && 'heartbeat' === sanitize_text_field( $_POST['action'] ) ) {
 			return false;
@@ -307,6 +315,8 @@ class ConstantContact_API {
 			return false;
 		}
 
+		update_option( 'ctct_acquiring_token', 'true', false );
+
 		$code_state = $options['_ctct_form_state_authcode'];
 
 		parse_str( $code_state, $parsed_code_state );
@@ -315,6 +325,7 @@ class ConstantContact_API {
 		if ( empty( $parsed_code_state[0] ) || empty( $parsed_code_state[1] ) ) {
 			$this->status_code = 0;
 			$this->last_error  = 'Invalid state or auth code';
+			add_filter( 'constant_contact_force_logging', '__return_true' );
 			constant_contact_maybe_log_it( 'Error: ', $this->last_error );
 
 			return false;
@@ -328,11 +339,13 @@ class ConstantContact_API {
 		if ( ( $state ?? 'undefined' ) != $expected_state ) {
 			$this->status_code = 0;
 			$this->last_error  = 'state is not correct';
+			add_filter( 'constant_contact_force_logging', '__return_true' );
 			constant_contact_maybe_log_it( 'Error: ', $this->last_error );
 
 			return false;
 		}
 
+		add_filter( 'constant_contact_force_logging', '__return_true' );
 		constant_contact_maybe_log_it( 'API', 'Access token triggered' );
 		// Create full request URL
 		$body = [
@@ -368,8 +381,10 @@ class ConstantContact_API {
 		$result = $this->exec( $url, $options, 'access' );
 
 		if ( false === $result ) {
+			add_filter( 'constant_contact_force_logging', '__return_true' );
 			constant_contact_maybe_log_it( 'Access Token:', 'Authentication to get access token error occurred' );
 			if ( ! empty( $this->last_error ) ) {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'Access Token:', 'Error: ' . $this->last_error );
 			}
 			constant_contact_set_needs_manual_reconnect( 'true' );
@@ -384,7 +399,7 @@ class ConstantContact_API {
 			constant_contact_set_needs_manual_reconnect( 'false' );
 		}
 
-
+		update_option( 'ctct_acquiring_token', 'false', false );
 		return $result;
 	}
 
@@ -417,6 +432,7 @@ class ConstantContact_API {
 			return $status;
 		}
 
+		add_filter( 'constant_contact_force_logging', '__return_true' );
 		constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh token triggered' );
 		update_option( 'ctct_refreshing_token', 'true', false );
 
@@ -450,8 +466,10 @@ class ConstantContact_API {
 		$result = $this->exec( $url, $options, 'refresh' );
 
 		if ( false === $result ) {
+			add_filter( 'constant_contact_force_logging', '__return_true' );
 			constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh error occurred' );
 			if ( ! empty( $this->last_error ) ) {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'Refresh Token:', 'Overall error: ' . $this->last_error );
 			}
 
@@ -462,14 +480,17 @@ class ConstantContact_API {
 			// Only require manual reconnect for invalid_grant (revoked/expired refresh
 			// token) or after 5 consecutive failures of any kind.
 			if ( false !== strpos( $this->last_error, 'invalid_grant' ) ) {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh token revoked (invalid_grant). Manual reconnect required.' );
 				constant_contact_set_needs_manual_reconnect( 'true' );
 				$status['reason'] = 'expired';
 			} elseif ( $failures >= 5 ) {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh failed ' . $failures . ' consecutive times. Manual reconnect required.' );
 				constant_contact_set_needs_manual_reconnect( 'true' );
 				$status['reason'] = 'max_retries_exceeded';
 			} else {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh failed (attempt ' . $failures . '/5). Will retry. Attempted at ' . current_datetime()->format( 'Y-n-d, H:i' ) );
 				$status['reason'] = 'transient_failure';
 				$this->refresh_token();
@@ -594,6 +615,7 @@ class ConstantContact_API {
 		if ( ! is_wp_error( $response ) ) {
 			if ( empty( $response['body'] ) ) {
 				$this->last_error = implode( ":", $response['response'] );
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it(
 					'Response error: ', implode( ":", $response['response'] )
 				);
@@ -603,6 +625,7 @@ class ConstantContact_API {
 			$json_last_error = json_last_error();
 			if ( JSON_ERROR_NONE !== $json_last_error ) {
 				$this->last_error = json_last_error_msg();
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'JSON error: ', json_last_error_msg() );
 			}
 
@@ -612,6 +635,7 @@ class ConstantContact_API {
 					$this->api_errors_admin_email();
 				}
 				$this->last_error = $data['error'] . ': ' . ( $data['error_description'] ?? 'Undefined' );
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'Error: ', $this->last_error );
 
 				return false;
@@ -652,6 +676,7 @@ class ConstantContact_API {
 		} else {
 			$this->status_code = 0;
 			$this->last_error  = $response->get_error_message();
+			add_filter( 'constant_contact_force_logging', '__return_true' );
 			constant_contact_maybe_log_it( 'Error: ', $this->last_error );
 		}
 
@@ -687,10 +712,12 @@ class ConstantContact_API {
 			try {
 				$acct_data = $this->cc()->get_account_info();
 				if ( array_key_exists( 'error_key', $acct_data ) && 'unauthorized' === $acct_data['error_key'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Re-attempting account info request.' );
 					$status = $this->refresh_token();
 
 					if ( ! $status['success'] ) {
+						add_filter( 'constant_contact_force_logging', '__return_true' );
 						constant_contact_maybe_log_it( 'API', 'Account info refresh request failed. Reason: ' . $status['reason'] );
 					}
 
@@ -735,10 +762,12 @@ class ConstantContact_API {
 			try {
 				$contacts = $this->cc()->get_contacts();
 				if ( array_key_exists( 'error_key', $contacts ) && 'unauthorized' === $contacts['error_key'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Re-attempting get contacts request.' );
 					$status = $this->refresh_token();
 
 					if ( ! $status['success'] ) {
+						add_filter( 'constant_contact_force_logging', '__return_true' );
 						constant_contact_maybe_log_it( 'API', 'Get contacts refresh request failed. Reason: ' . $status['reason'] );
 					}
 
@@ -798,10 +827,12 @@ class ConstantContact_API {
 
 			$return_contact = $this->create_update_contact( $list, $email, $new_contact, $form_id );
 			if ( array_key_exists( 'error_key', $return_contact ) && 'unauthorized' === $return_contact['error_key'] ) {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'API', 'Re-attempting contact request.' );
 				$status = $this->refresh_token();
 
 				if ( ! $status['success'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Add contact refresh request failed. Reason: ' . $status['reason'] );
 				}
 
@@ -1084,10 +1115,12 @@ class ConstantContact_API {
 				$lists = $results['lists'] ?? [];
 
 				if ( array_key_exists( 'error_key', $results ) && 'unauthorized' === $results['error_key'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Re-attempting get lists request.' );
 					$status = $this->refresh_token();
 
 					if ( ! $status['success'] ) {
+						add_filter( 'constant_contact_force_logging', '__return_true' );
 						constant_contact_maybe_log_it( 'API', 'Get list refresh request failed. Reason: ' . $status['reason'] );
 					}
 
@@ -1194,10 +1227,12 @@ class ConstantContact_API {
 			try {
 				$list = $this->cc()->get_list( $id );
 				if ( array_key_exists( 'error_key', $list ) && 'unauthorized' === $list['error_key'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Re-attempting get single list request.' );
 					$status = $this->refresh_token();
 
 					if ( ! $status['success'] ) {
+						add_filter( 'constant_contact_force_logging', '__return_true' );
 						constant_contact_maybe_log_it( 'API', 'Get single list refresh request failed. Reason: ' . $status['reason'] );
 					}
 
@@ -1245,10 +1280,12 @@ class ConstantContact_API {
 			try {
 				$list = $this->cc()->get_list( esc_attr( $new_list['id'] ) );
 				if ( array_key_exists( 'error_key', $list ) && 'unauthorized' === $list['error_key'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Re-attempting add list request.' );
 					$status = $this->refresh_token();
 
 					if ( ! $status['success'] ) {
+						add_filter( 'constant_contact_force_logging', '__return_true' );
 						constant_contact_maybe_log_it( 'API', 'Add list refresh request failed. Reason: ' . $status['reason'] );
 					}
 
@@ -1335,10 +1372,12 @@ class ConstantContact_API {
 
 			$return_list = $this->cc()->update_list( $list );
 			if ( array_key_exists( 'error_key', $return_list ) && 'unauthorized' === $return_list['error_key'] ) {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'API', 'Re-attempting update list request.' );
 				$status = $this->refresh_token();
 
 				if ( ! $status['success'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Update list refresh request failed. Reason: ' . $status['reason'] );
 				}
 				$return_list = $this->cc()->update_list( $list );
@@ -1378,10 +1417,12 @@ class ConstantContact_API {
 		try {
 			$list = $this->cc()->delete_list( $updated_list['id'] );
 			if ( array_key_exists( 'error_key', $list ) && 'unauthorized' === $list['error_key'] ) {
+				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'API', 'Re-attempting delete list request.' );
 				$status = $this->refresh_token();
 
 				if ( ! $status['success'] ) {
+					add_filter( 'constant_contact_force_logging', '__return_true' );
 					constant_contact_maybe_log_it( 'API', 'Delete list refresh request failed. Reason: ' . $status['reason'] );
 				}
 				$list = $this->cc()->delete_list( $updated_list['id'] );

--- a/includes/class-block.php
+++ b/includes/class-block.php
@@ -35,22 +35,7 @@ class ConstantContact_Block {
 	public function __construct( object $plugin ) {
 		$this->plugin = $plugin;
 
-		if ( $this->meets_requirements() ) {
-			add_action( 'init', [ $this, 'register_blocks' ] );
-		}
-	}
-
-	/**
-	 * Check requirements.
-	 *
-	 * @author Eric Fuller
-	 * @since  1.5.0
-	 * @return bool
-	 */
-	private function meets_requirements() : bool {
-		global $wp_version;
-
-		return version_compare( $wp_version, '5.0.0' ) >= 0;
+		add_action( 'init', [ $this, 'register_blocks' ] );
 	}
 
 	/**

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -159,6 +159,7 @@ class ConstantContact_Connect {
 				$description = esc_html__( 'Issues with reauthentication for tokens occurred and a manual disconnect and reconnect is needed. Use the status button to start the re-authentication process.', 'constant-contact-forms' );
 				$btn_value   = esc_attr__( 'Disconnected', 'constant-contact-forms' );
 			}
+			$times = constant_contact_get_issued_expired_access_token_times();
 			?>
 			<div class="wrap connected <?php echo esc_attr( $this->key ); ?>">
 				<div class="ctct-connected">
@@ -205,6 +206,26 @@ class ConstantContact_Connect {
 								?>
 							</p>
 						</div>
+						<?php if ( $times ) : ?>
+						<div class="ctct-connection-details">
+							<p class="ctct-label">
+								<strong><?php esc_html_e( 'Issued time:', 'constant-contact-forms' ); ?></strong>
+							</p>
+							<p><?php echo esc_html( $times['issued'] ); ?></p>
+						</div>
+						<div class="ctct-connection-details">
+							<p class="ctct-label">
+								<strong><?php esc_html_e( 'Current time:', 'constant-contact-forms' ); ?></strong>
+							</p>
+							<p><?php echo esc_html( $times['current'] ); ?></p>
+						</div>
+						<div class="ctct-connection-details">
+							<p class="ctct-label">
+								<strong><?php esc_html_e( 'Estimated expiration time:', 'constant-contact-forms' ); ?></strong>
+							</p>
+							<p><?php echo esc_html( $times['expires'] ); ?></p>
+						</div>
+						<?php endif; ?>
 						<div class="ctct-connection-details">
 							<p class="ctct-label">
 								<strong><?php esc_html_e( 'Status:', 'constant-contact-forms' ); ?></strong>

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -385,9 +385,15 @@ class ConstantContact_Connect {
 			return false;
 		}
 
+		// Cases where we may not have vendor loaded yet?
+		constant_contact()->load_libs();
+
 		if ( wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['ctct-admin-disconnect'] ) ), 'ctct-admin-disconnect' ) ) {
+			add_filter( 'constant_contact_force_logging', '__return_true' );
+			constant_contact_maybe_log_it( 'API', 'Manual disconnect' );
 			$this->force_disconnect();
 		} else {
+			add_filter( 'constant_contact_force_logging', '__return_true' );
 			constant_contact_maybe_log_it( 'Nonces', 'Account disconnection nonce failed to verify.' );
 		}
 		return true;
@@ -398,9 +404,17 @@ class ConstantContact_Connect {
 	 *
 	 * @since 2.19.0
 	 *
+	 * @param bool $skip_disconnect Whether or not to actually disconnect
 	 * @return bool
 	 */
-	public function force_disconnect() : bool {
+	public function force_disconnect( $skip_disconnect = false ) : bool {
+		add_filter( 'constant_contact_force_logging', '__return_true' );
+		constant_contact_maybe_log_it( 'API', 'Force disconnect reached' );
+
+		if ( $skip_disconnect ) {
+			return false;
+		}
+
 		delete_option( 'ctct_access_token' );
 		delete_option( '_ctct_access_token' );
 		delete_option( 'ctct_refresh_token' );
@@ -408,6 +422,7 @@ class ConstantContact_Connect {
 		delete_option( '_ctct_expires_in' );
 		delete_option( 'ctct_maybe_needs_reconnected' );
 		delete_option( 'ctct_account_domain_hash' );
+		delete_option( 'ctct_acquiring_token' );
 		delete_option( 'ctct_refreshing_token' );
 
 		delete_option( 'CtctConstantContactcode_verifier' );

--- a/includes/class-mail.php
+++ b/includes/class-mail.php
@@ -154,10 +154,13 @@ class ConstantContact_Mail {
 		$lists        = $values['ctct-lists'] ?? [];
 		$lists        = $lists['value'] ?? [];
 		$args['list'] = is_array( $lists ) ? array_map( 'sanitize_text_field', $lists ) : sanitize_text_field( $lists );
-		$args['anniversary'] = [
-			'key' => 'anniversary',
-			'val' => $this->format_anniversary_date( $date_parts ),
-		];
+
+		if ( ! empty( $date_parts ) ) {
+			$args['anniversary'] = [
+				'key' => 'anniversary',
+				'val' => $this->format_anniversary_date( $date_parts ),
+			];
+		}
 		return constant_contact()->get_api()->add_contact( $args, $values['ctct-id']['value'] );
 	}
 

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -838,6 +838,14 @@ function constant_contact_get_date_field_order( $format = '' ) {
 	return $order;
 }
 
+/**
+ * Return an array of timestamps for issued, current, and expected expiration time for current access token.
+ *
+ * @since NEXT
+ *
+ * @return array|null
+ * @throws Exception
+ */
 function constant_contact_get_issued_expired_access_token_times() {
 	$token_timestamp = get_option( 'ctct_access_token_timestamp', '' );
 	if ( empty( $token_timestamp ) ) {

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -837,3 +837,19 @@ function constant_contact_get_date_field_order( $format = '' ) {
 
 	return $order;
 }
+
+function constant_contact_get_issued_expired_access_token_times() {
+	$token_timestamp = get_option( 'ctct_access_token_timestamp', '' );
+	if ( empty( $token_timestamp ) ) {
+		return null;
+	}
+	$date = date( 'Y-m-d, H:i', $token_timestamp );
+	$obj  = new DateTime( $date );
+	$obj->modify( '+1 day' );
+
+	return [
+		'issued'  => $date,
+		'current' => date( 'Y-m-d, H:i', time() ),
+		'expires' => $obj->format( 'Y-m-d, H:i' ),
+	];
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "constant-contact-forms",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constant-contact-forms",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "description": "",
   "main": "build/index.js",
   "engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      constantcontact, webdevstudios, tw2113, znowebdev, ggwicz, ra
 Tags: constant contact, constant contact official, marketing, newsletter, contacts
 Requires at least: 6.4.0
 Tested up to:      7.0
-Stable tag:        2.20.0
+Stable tag:        2.21.0
 License:           GPLv3
 License URI:       http://www.gnu.org/licenses/gpl-3.0.html
 Requires PHP:      8.1
@@ -46,6 +46,15 @@ Development of Constant Contact Forms plugin occurs on [GitHub](https://github.c
 5. Basic Form
 
 == Changelog ==
+
+= 2.21.0 =
+* Updated: Temporarily removing the forced disconnection and API key removal, when domain differences are suspected. Added logging indicating we got to that point.
+* Updated: Force logging before various logging lines to help ensure we're going to log troubleshooting data.
+* Updated: Wording of connection status in upper right corner for better clarity.
+* Updated: Removed PHP version requirement checks that are now handled by WordPress
+* Added: Reduced potential race conditions with initial authentication process.
+* Added: Token issued, current, and estimated expiration times to status page.
+* Fixed: Conditionally add anniversary details in successful signup log, if anniversary field used.
 
 = 2.20.0 =
 * Updated: Reduced race conditions that were potentially contributing to connection stability.


### PR DESCRIPTION
* Updated: Temporarily removing the forced disconnection and API key removal, when domain differences are suspected. Added logging indicating we got to that point.
* Updated: Force logging before various logging lines to help ensure we're going to log troubleshooting data.
* Updated: Wording of connection status in upper right corner for better clarity.
* Updated: Removed PHP version requirement checks that are now handled by WordPress
* Added: Reduced potential race conditions with initial authentication process.
* Added: Token issued, current, and estimated expiration times to status page.
* Fixed: Conditionally add anniversary details in successful signup log, if anniversary field used.