### PR TITLE
Feature/con 547 api test trigger

### DIFF
--- a/assets/js/ctct-plugin-admin/ajax.js
+++ b/assets/js/ctct-plugin-admin/ajax.js
@@ -12,6 +12,7 @@ window.CTCTAJAX = {};
 
 		// Trigger any field modifications we need to do.
 		that.handleReviewAJAX();
+		that.handleAPITest();
 	};
 
 	// Handle saving the decision regarding the review prompt admin notice.
@@ -42,6 +43,36 @@ window.CTCTAJAX = {};
 					.then((response) => {
 						if (response.success) {
 							reviewRequest.style.display = 'none';
+						}
+					}).catch((error) => {
+					console.log(error);
+				});
+			});
+		}
+	};
+
+	that.handleAPITest = () => {
+		const apitestlink = document.querySelector('#ctct-test-api');
+		if (apitestlink) {
+			apitestlink.addEventListener('click', (e) => {
+				e.preventDefault();
+
+				const data = new FormData();
+				data.append('action', 'constant_contact_test_api_ajax_handler');
+
+				const params = new URLSearchParams(e.target.href);
+
+				if (params.get('ctct-test-connection')) {
+					data.append('ctct-test-connection-nonce', params.get('ctct-test-connection'));
+				}
+
+				fetch(window.ajaxurl, options = {
+					method: 'POST', body: data,
+				})
+					.then((response) => response.json())
+					.then((response) => {
+						if (response.success) {
+							document.querySelector('#ctct-test-api-result').innerHTML = response.data.is_connected;
 						}
 					}).catch((error) => {
 					console.log(error);

--- a/assets/js/ctct-plugin-admin/ajax.js
+++ b/assets/js/ctct-plugin-admin/ajax.js
@@ -71,8 +71,13 @@ window.CTCTAJAX = {};
 				})
 					.then((response) => response.json())
 					.then((response) => {
+						const successDOM = document.querySelector('#ctct-test-api-result');
+						successDOM.innerHTML = response.data.is_connected;
+						successDOM.setAttribute('class', '');
 						if (response.success) {
-							document.querySelector('#ctct-test-api-result').innerHTML = response.data.is_connected;
+							successDOM.classList.add('success');
+						} else {
+							successDOM.classList.add('no-success');
 						}
 					}).catch((error) => {
 					console.log(error);

--- a/assets/sass/_admin-connect.scss
+++ b/assets/sass/_admin-connect.scss
@@ -347,6 +347,18 @@
 			}
 		}
 	}
+
+	#ctct-test-api-result {
+		font-weight: bold;
+		margin-left: 10px;
+		&.success {
+			color: variables.$color-success-dark;
+		}
+
+		&.no-success {
+			color: variables.$color-error-dark;
+		}
+	}
 }
 
 // Getting Started/ Next Steps

--- a/assets/sass/_admin-connect.scss
+++ b/assets/sass/_admin-connect.scss
@@ -316,8 +316,7 @@
 }
 
 // Connection Details
-.ctct-connected-wrap{
-
+.ctct-connected-wrap {
 	.ctct-connection-details{
 		display: flex;
 		text-align: left;
@@ -343,10 +342,6 @@
 		}
 
 		p{
-			overflow: hidden;
-			white-space: nowrap;
-			text-overflow: ellipsis;
-
 			&.ctct-label{
 				justify-content: flex-end;
 			}

--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -23,7 +23,9 @@ $color-black-translucent: rgba(0,0,0, 0.5);
 
 // Theming
 $color-error: $color-red;
+$color-error-dark: #a90b00;
 $color-success: $color-green;
+$color-success-dark: #1c7727;
 
 // constant contact colors
 $color-sky-blue: #88c5e2;

--- a/includes/class-client.php
+++ b/includes/class-client.php
@@ -442,7 +442,7 @@ class ConstantContact_Client {
 	/**
 	 * Method to do a basic API request test, to check on current credentials.
 	 *
-	 * @since NEXT
+	 * @since 2.22.0
 	 *
 	 * @param array $args
 	 * @return bool
@@ -455,7 +455,7 @@ class ConstantContact_Client {
 			/**
 			 * Sets the HTTP timeout, in seconds, for the request.
 			 *
-			 * @since NEXT
+			 * @since 2.22.0
 			 *
 			 * @param int    $value       The timeout limit, in seconds. Defaults to 30.
 			 * @param string $request_url The request URL.

--- a/includes/class-client.php
+++ b/includes/class-client.php
@@ -273,6 +273,10 @@ class ConstantContact_Client {
 		return $this->get( "contact_lists/list_id_xrefs?sequence_ids={$old_ids_string}", $this->base_args );
 	}
 
+	public function test_connection() {
+		return $this->test( $this->base_args );
+	}
+
 	/**
 	 * GET method for API requests.
 	 *
@@ -433,5 +437,42 @@ class ConstantContact_Client {
 		}
 
 		return json_decode( $response['body'], true );
+	}
+
+	/**
+	 * Method to do a basic API request test, to check on current credentials.
+	 *
+	 * @since NEXT
+	 *
+	 * @param array $args
+	 * @return bool
+	 */
+	private function test( array $args = [] ): bool {
+
+		$url = $this->base_url . '/account/user/privileges';
+
+		$options = [
+			/**
+			 * Sets the HTTP timeout, in seconds, for the request.
+			 *
+			 * @since NEXT
+			 *
+			 * @param int    $value       The timeout limit, in seconds. Defaults to 30.
+			 * @param string $request_url The request URL.
+			 *
+			 * @return int
+			 */
+			'timeout' => apply_filters( 'http_request_timeout', 30, $url ),
+			'headers' => $args,
+		];
+
+		$response = wp_safe_remote_get( $url, $options );
+		if ( is_wp_error( $response ) ) {
+			return false;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+
+		return 200 === $code;
 	}
 }

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -157,7 +157,7 @@ class ConstantContact_Connect {
 			if ( constant_contact_get_needs_manual_reconnect() ) {
 				$heading     = esc_html__( 'Manual reconnection required', 'constant-contact-forms' );
 				$description = esc_html__( 'Issues with reauthentication for tokens occurred and a manual disconnect and reconnect is needed. Use the status button to start the re-authentication process.', 'constant-contact-forms' );
-				$btn_value   = esc_attr__( 'Disconnected', 'constant-contact-forms' );
+				$btn_value   = esc_attr__( 'Force disconnect', 'constant-contact-forms' );
 			}
 			$times = constant_contact_get_issued_expired_access_token_times();
 			?>
@@ -228,22 +228,21 @@ class ConstantContact_Connect {
 						<?php endif; ?>
 						<div class="ctct-connection-details">
 							<p class="ctct-label">
-								<strong><?php esc_html_e( 'Status:', 'constant-contact-forms' ); ?></strong>
+								<strong><?php esc_html_e( 'Test status:', 'constant-contact-forms' ); ?></strong>
+							</p>
+							<p><a id="ctct-test-api" href="<?php echo esc_url( wp_nonce_url(admin_url('edit.php?post_type=ctct_forms&page=ctct_options_connect'), 'ctct-test-connection', 'ctct-test-connection' ) ); ?>"><?php esc_html_e('Test current API key', 'constant-contact-forms' ); ?></a>
+							 <span id="ctct-test-api-result"></span>
+							</p>
+						</div>
+						<div class="ctct-connection-details">
+							<p class="ctct-label">
+								<strong><?php esc_html_e( 'Action:', 'constant-contact-forms' ); ?></strong>
 							</p>
 							<form method="post" action="<?php echo esc_url( $this->redirect_url ); ?>">
 								<?php wp_nonce_field( 'ctct-admin-disconnect', 'ctct-admin-disconnect' ); ?>
 								<input type="hidden" id="ctct-disconnect" name="ctct-disconnect" value="true">
 								<input type="submit" class="button button-primary ctct-disconnect" value="<?php echo esc_attr( $btn_value ); ?>">
 							</form>
-						</div>
-
-						<div class="ctct-connection-details">
-							<p class="ctct-label">
-								<strong><?php esc_html_e( 'Test status:', 'constant-contact-forms' ); ?></strong>
-							</p>
-							<p><a id="ctct-test-api" href="<?php echo esc_url( wp_nonce_url(admin_url('edit.php?post_type=ctct_forms&page=ctct_options_connect'), 'ctct-test-connection', 'ctct-test-connection' ) ); ?>"><?php esc_html_e('Test current API key', 'constant-contact-forms' ); ?></a>
-							 <span id="ctct-test-api-result"></span>
-							</p>
 						</div>
 					</div>
 

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -236,6 +236,15 @@ class ConstantContact_Connect {
 								<input type="submit" class="button button-primary ctct-disconnect" value="<?php echo esc_attr( $btn_value ); ?>">
 							</form>
 						</div>
+
+						<div class="ctct-connection-details">
+							<p class="ctct-label">
+								<strong><?php esc_html_e( 'Test status:', 'constant-contact-forms' ); ?></strong>
+							</p>
+							<p><a id="ctct-test-api" href="<?php echo esc_url( wp_nonce_url(admin_url('edit.php?post_type=ctct_forms&page=ctct_options_connect'), 'ctct-test-connection', 'ctct-test-connection' ) ); ?>"><?php esc_html_e('Test current API key', 'constant-contact-forms' ); ?></a>
+							 <span id="ctct-test-api-result" style="display:block; margin-left: 5px;"></span>
+							</p>
+						</div>
 					</div>
 
 					<hr />

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -242,7 +242,7 @@ class ConstantContact_Connect {
 								<strong><?php esc_html_e( 'Test status:', 'constant-contact-forms' ); ?></strong>
 							</p>
 							<p><a id="ctct-test-api" href="<?php echo esc_url( wp_nonce_url(admin_url('edit.php?post_type=ctct_forms&page=ctct_options_connect'), 'ctct-test-connection', 'ctct-test-connection' ) ); ?>"><?php esc_html_e('Test current API key', 'constant-contact-forms' ); ?></a>
-							 <span id="ctct-test-api-result" style="display:block; margin-left: 5px;"></span>
+							 <span id="ctct-test-api-result"></span>
 							</p>
 						</div>
 					</div>

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -861,3 +861,16 @@ function constant_contact_get_issued_expired_access_token_times() {
 		'expires' => $obj->format( 'Y-m-d, H:i' ),
 	];
 };
+
+function constant_contact_test_api_ajax_handler(): bool {
+	if ( ! wp_verify_nonce( $_REQUEST['ctct-test-connection-nonce'], 'ctct-test-connection' ) ) {
+		wp_send_json_error( [ 'nonce-result' => 'failed' ] );
+		exit();
+	}
+	$is_connected = constant_contact()->get_api()->cc()->test_connection();
+	$is_connected ?
+		wp_send_json_success( [ 'is_connected' => 'did connect' ], 200 ) :
+		wp_send_json_success( [ 'is_connected' => 'did not connect' ], 200 );
+	exit();
+}
+add_action( 'wp_ajax_constant_contact_test_api_ajax_handler', 'constant_contact_test_api_ajax_handler' );

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -863,10 +863,16 @@ function constant_contact_get_issued_expired_access_token_times() {
 };
 
 function constant_contact_test_api_ajax_handler(): bool {
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		exit();
+	}
+
 	if ( ! wp_verify_nonce( $_REQUEST['ctct-test-connection-nonce'], 'ctct-test-connection' ) ) {
 		wp_send_json_error( [ 'nonce-result' => 'failed' ] );
 		exit();
 	}
+
 	$is_connected = constant_contact()->get_api()->cc()->test_connection();
 	$is_connected ?
 		wp_send_json_success( [ 'is_connected' => 'did connect' ], 200 ) :

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -870,7 +870,7 @@ function constant_contact_test_api_ajax_handler(): bool {
 	$is_connected = constant_contact()->get_api()->cc()->test_connection();
 	$is_connected ?
 		wp_send_json_success( [ 'is_connected' => 'did connect' ], 200 ) :
-		wp_send_json_success( [ 'is_connected' => 'did not connect' ], 200 );
+		wp_send_json_error( [ 'is_connected' => 'did not connect' ], 200 );
 	exit();
 }
 add_action( 'wp_ajax_constant_contact_test_api_ajax_handler', 'constant_contact_test_api_ajax_handler' );

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -841,7 +841,7 @@ function constant_contact_get_date_field_order( $format = '' ) {
 /**
  * Return an array of timestamps for issued, current, and expected expiration time for current access token.
  *
- * @since NEXT
+ * @since 2.21.0
  *
  * @return array|null
  * @throws Exception

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -862,6 +862,15 @@ function constant_contact_get_issued_expired_access_token_times() {
 	];
 };
 
+/**
+ * Make a test API request to a general endpoint.
+ *
+ * Meant to just verify access tokens are still valid.
+ *
+ * @since 2.22.0
+ *
+ * @return bool
+ */
 function constant_contact_test_api_ajax_handler(): bool {
 
 	if ( ! current_user_can( 'manage_options' ) ) {


### PR DESCRIPTION
# Handles

[CON-547](https://app.clickup.com/t/9011385391/CON-547)

## Description

This PR adds a new AJAX-powered link to do a test API request, to verify that the current access token is still working and valid.

It also does some rewording of the left side columns to help with clarity of what the given row is meant for.

### Success
<img width="702" height="178" alt="Screenshot 2026-07-07 at 11 30 24 AM" src="https://github.com/user-attachments/assets/5ad08398-6d88-4267-8ab0-af77c71e8ad2" />

### No success
<img width="742" height="162" alt="Screenshot 2026-07-07 at 11 30 50 AM" src="https://github.com/user-attachments/assets/d94cd6a0-ff52-4a1b-bac0-298bd6092292" />
