### PR TITLE
Fix/con 553 encryption usage

### DIFF
--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -648,11 +648,11 @@ class ConstantContact_Connect {
 			$return = false;
 			Constant_Contact::get_instance()->load_libs();
 
-			if ( class_exists( 'Defuse\Crypto\RuntimeTests' ) ) {
+			if ( class_exists( 'ConstantContact\ConstantContactForms\Defuse\Crypto\RuntimeTests' ) ) {
 
 				// If we have our Crpyto class, we'll run the included
 				// runtime tests and see if we get the correct response.
-				$tests  = new Defuse\Crypto\RuntimeTests();
+				$tests  = new ConstantContact\ConstantContactForms\Defuse\Crypto\RuntimeTests();
 				$tests::runtimeTest();
 				$return = true;
 			}

--- a/includes/class-connect.php
+++ b/includes/class-connect.php
@@ -468,25 +468,24 @@ class ConstantContact_Connect {
 		if ( $fallback_to_ctct_opt ) {
 			$options = get_option( 'ctct_options_settings', false );
 			if ( $options && isset( $options[ $check_key ] ) ) {
-				$encrypted_token = $options[ $check_key ];
+				$maybe_encrypted_token = $options[ $check_key ];
 			} else {
 				return false;
 			}
 		} else {
-			$encrypted_token = get_option( $check_key );
-			if ( ! $encrypted_token ) {
+			$maybe_encrypted_token = get_option( $check_key );
+			if ( ! $maybe_encrypted_token ) {
 				return false;
 			}
 		}
 
 		try {
-			$return = Crypto::decrypt( $encrypted_token, $key );
+			$return = Crypto::decrypt( $maybe_encrypted_token, $key );
 		} catch ( Exception $e ) {
-			$return = '';
+			$return = $maybe_encrypted_token;
 		}
 
 		return $return;
-
 	}
 
 	/**


### PR DESCRIPTION
This PR adjusts the class name string we're checking for which should ensure that we're actually encrypting database values.

We also adjust the exception return value to prevent needing to manually re-connect which has plagued us. The return value will be the presently saved un-encrypted version, that will not last past the next refresh of data.