### PR TITLE
add a sleep call for 2 seconds in automated refresh attempts. Should help prevent Error 429 "too many requests" errors

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -493,6 +493,9 @@ class ConstantContact_API {
 				add_filter( 'constant_contact_force_logging', '__return_true' );
 				constant_contact_maybe_log_it( 'Refresh Token:', 'Refresh failed (attempt ' . $failures . '/5). Will retry. Attempted at ' . current_datetime()->format( 'Y-n-d, H:i' ) );
 				$status['reason'] = 'transient_failure';
+
+				sleep( 2 );
+
 				$this->refresh_token();
 			}
 


### PR DESCRIPTION
# Handles
[CON-555](https://app.clickup.com/t/9011385391/CON-555)

This PR adds a short sleep call in what is ultimately a recursive spot, to prevent API speed errors.