### PR TITLE
Fix/con 554 cmb2 settings page

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1486,7 +1486,7 @@ class ConstantContact_API {
 		}
 
 		$disclosure = [
-			'name'    => empty( $account_info->organization_name ) ? constant_contact_get_option( '_ctct_disclose_name', '' ) : $account_info->organization_name,
+			'name'    => empty( $account_info['organization_name'] ) ? constant_contact_get_option( '_ctct_disclose_name', '' ) : $account_info['organization_name'],
 			'address' => constant_contact_get_option( '_ctct_disclose_address', '' ),
 		];
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -499,27 +499,25 @@ class ConstantContact_Settings {
 					]
 				);
 
-				if ( empty( $disclosure_info ) ) {
-					$cmb->add_field(
-						[
-							'name'       => esc_html__( 'Disclosure Name', 'constant-contact-forms' ),
-							'id'         => '_ctct_disclose_name',
-							'type'       => 'text',
-							'default'    => $business_name,
-							'attributes' => ! empty( $business_name ) ? [ 'readonly' => 'readonly' ] : [],
-						]
-					);
+				$cmb->add_field(
+					[
+						'name'       => esc_html__( 'Disclosure Name', 'constant-contact-forms' ),
+						'id'         => '_ctct_disclose_name',
+						'type'       => 'text',
+						'default'    => $business_name,
+						'attributes' => ! empty( $business_name ) ? [ 'readonly' => 'readonly' ] : [],
+					]
+				);
 
-					$cmb->add_field(
-						[
-							'name'       => esc_html__( 'Disclosure Address', 'constant-contact-forms' ),
-							'id'         => '_ctct_disclose_address',
-							'type'       => 'text',
-							'default'    => $business_addr,
-							'attributes' => ! empty( $business_addr ) ? [ 'readonly' => 'readonly' ] : [],
-						]
-					);
-				}
+				$cmb->add_field(
+					[
+						'name'       => esc_html__( 'Disclosure Address', 'constant-contact-forms' ),
+						'id'         => '_ctct_disclose_address',
+						'type'       => 'text',
+						'default'    => $business_addr,
+						'attributes' => ! empty( $business_addr ) ? [ 'readonly' => 'readonly' ] : [],
+					]
+				);
 
 				$cmb->add_field(
 					[

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -451,7 +451,9 @@ class ConstantContact_Settings {
 		$cmb = new_cmb2_box( $this->get_cmb_args( 'optin' ) );
 
 		if ( empty( $_GET['page'] ) || 'ctct_options_settings_optin' !== $_GET['page'] ) {
-			return;
+			if ( empty( $_POST ) ) {
+				return;
+			}
 		}
 
 		if ( constant_contact()->get_api()->is_connected() ) {


### PR DESCRIPTION
# Handles

[CON-554](https://app.clickup.com/t/9011385391/CON-554)

This PR adjusts early return to allow for successful saving of settings on the Opt-in page, that is causing us to lose all our settings from CMB2.

It also adjusts account information variable types to successfully refer to data.

Last, it shows the disclosure fields regardless of api vs local setting.