### PR TITLE
Fix/con 542 protocol hash comparison edits

### DIFF
--- a/includes/class-api-utility.php
+++ b/includes/class-api-utility.php
@@ -196,7 +196,7 @@ class ConstantContact_API_Utility {
 				return [];
 			}
 			$connecting_account['account'] = $parsed_payload_data['sub'];
-			$connecting_account['site']    = get_site_url();
+			$connecting_account['site']    = parse_url( get_site_url(), PHP_URL_HOST );
 		}
 
 		return $connecting_account;

--- a/includes/class-updates.php
+++ b/includes/class-updates.php
@@ -42,7 +42,7 @@ class ConstantContact_Updates {
 	 *
 	 * @since 1.0.0
 	 */
-	public function hooks() {
+	public function hooks(): void {
 		if ( is_admin() ) {
 			add_action( 'plugins_loaded', [ $this, 'check_for_update_needed' ] );
 		}
@@ -54,7 +54,7 @@ class ConstantContact_Updates {
 	 *
 	 * @since 1.0.0
 	 */
-	public function check_for_update_needed() {
+	public function check_for_update_needed(): void {
 
 		$installed = get_option( 'ctct_plugin_version', '0.0.0' );
 		$current   = esc_attr( $this->plugin->version );
@@ -88,7 +88,7 @@ class ConstantContact_Updates {
 	 *
 	 * @param string $update_id Update key to use for version.
 	 */
-	public function add_notification( string $update_id ) {
+	public function add_notification( string $update_id ): void {
 
 		$current_notifs = get_option( 'ctct_update_notifications', [] );
 		$compare_notifs = $current_notifs;
@@ -118,7 +118,7 @@ class ConstantContact_Updates {
 	 *
 	 * @since 2.22.0
 	 */
-	public function run_update_v2_19_0_to_v2_22_0() {
+	public function run_update_v2_19_0_to_v2_22_0(): void {
 		update_option( 'ctct_account_domain_hash', '' );
 	}
 
@@ -129,7 +129,7 @@ class ConstantContact_Updates {
 	 *
 	 * @since 2.22.0
 	 */
-	public function run_update_v2_20_0_to_v2_22_0() {
+	public function run_update_v2_20_0_to_v2_22_0(): void {
 		update_option( 'ctct_account_domain_hash', '' );
 	}
 
@@ -140,7 +140,7 @@ class ConstantContact_Updates {
 	 *
 	 * @since 2.22.0
 	 */
-	public function run_update_v2_21_0_to_v2_22_0() {
+	public function run_update_v2_21_0_to_v2_22_0(): void {
 		update_option( 'ctct_account_domain_hash', '' );
 	}
 }

--- a/includes/class-updates.php
+++ b/includes/class-updates.php
@@ -59,7 +59,7 @@ class ConstantContact_Updates {
 		$installed = get_option( 'ctct_plugin_version', '0.0.0' );
 		$current   = esc_attr( $this->plugin->version );
 
-		if ( ! version_compare( $current, $installed, '<' ) ) {
+		if ( ! version_compare( $current, $installed, '<' ) && $current !== $installed ) {
 
 			update_option( 'ctct_plugin_version', $current, true );
 
@@ -111,4 +111,36 @@ class ConstantContact_Updates {
 		}
 	}
 
+	/**
+	 * Version 2.19.0 to 2.22.0.
+	 *
+	 * Force delete this option value due to changing how much gets hashed.
+	 *
+	 * @since 2.22.0
+	 */
+	public function run_update_v2_19_0_to_v2_22_0() {
+		update_option( 'ctct_account_domain_hash', '' );
+	}
+
+	/**
+	 * Version 2.20.0 to 2.22.0
+	 *
+	 * Force delete this option value due to changing how much gets hashed.
+	 *
+	 * @since 2.22.0
+	 */
+	public function run_update_v2_20_0_to_v2_22_0() {
+		update_option( 'ctct_account_domain_hash', '' );
+	}
+
+	/**
+	 * Version 2.21.0 to 2.22.0
+	 *
+	 * Force delete this option value due to changing how much gets hashed.
+	 *
+	 * @since 2.22.0
+	 */
+	public function run_update_v2_21_0_to_v2_22_0() {
+		update_option( 'ctct_account_domain_hash', '' );
+	}
 }


### PR DESCRIPTION
# Handles

[https://app.clickup.com/t/9011385391/CON-542](https://app.clickup.com/t/9011385391/CON-542)

## Description

This PR removes the protocol from our connection status hashes to help avoid differences from `http` vs `https`. We'll just store the hostname.

This PR also updates our `updates` class' usage of version compare to not have things run when the versions match.

Lastly, it utilizes our `updates` class to delete our previous stored hash used for domain differences, so that it doesn't try to compare protocol'd version. It handles the releases that have the option included, so before 2.19.0 isn't affected.